### PR TITLE
use `@ingredients` from PlutoLinks

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -6,13 +6,14 @@ version = "0.1.4"
 [deps]
 LaTeXStrings = "b964fa9f-0449-5b57-a5c2-d3ea65f4040f"
 Markdown = "d6f4376e-aef5-505a-96c1-9c027394607a"
+PlutoLinks = "0ff47ea0-7a50-410d-8455-4348d5de0420"
 PlutoUI = "7f904dfe-b85e-4ff6-b463-dae2292396a8"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 
 [compat]
 LaTeXStrings = "1"
-julia = "1"
 PlutoUI = "0.7"
+julia = "1"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/README.md
+++ b/README.md
@@ -5,13 +5,14 @@ Math from computation, math with computation (Spring 2021)](https://computationa
 
 I've also added:
 - WidthOverDocs from [PlutoThemes.jl](https://github.com/JuliaPluto/PlutoThemes.jl)
-- ingredients(path) from a [Pluto.jl discussion](https://github.com/fonsp/Pluto.jl/issues/115)
+- `@ingredients(path)` from [PlutoLinks.jl](https://github.com/JuliaPluto/PlutoLinks.jl)
 
 I hope that I and others will improve and/or contribute new functions that are of value to other educaitons.  PRs welcome.
 
 # Acknowledgements
 - [Pluto](https://github.com/fonsp/Pluto.jl)
 - [PlutoUI](https://github.com/fonsp/PlutoUI.jl)
+- [PlutoLinks.jl](https://github.com/JuliaPluto/PlutoLinks.jl)
 - [PlutoThemes.jl](https://github.com/JuliaPluto/PlutoThemes.jl)
 - Some material on this website is based on "Computational Thinking, a live online Julia/Pluto textbook, https://computationalthinking.mit.edu"
 

--- a/src/PlutoTeachingTools.jl
+++ b/src/PlutoTeachingTools.jl
@@ -2,6 +2,9 @@ module PlutoTeachingTools
 
 using PlutoUI
 
+using PlutoLinks: @ingredients
+export @ingredients
+
 include("computational_thinking.jl")
 include("present.jl")
 include("latex.jl")

--- a/src/other.jl
+++ b/src/other.jl
@@ -1,24 +1,4 @@
-export ingredients
 export WidthOverDocs
-
-"""
-   ingredients(path) allows Pluto notebooks to include a module from another file.
-It's like include, but for inside a pluto notebook.
-Source: https://github.com/fonsp/Pluto.jl/issues/115
-"""
-function ingredients(path::String)
-	# this is from the Julia source code (evalfile in base/loading.jl)
-	# but with the modification that it returns the module instead of the last object
-	name = Symbol(basename(path))
-	m = Module(name)
-	Core.eval(m,
-        Expr(:toplevel,
-             :(eval(x) = $(Expr(:core, :eval))($name, x)),
-             :(include(x) = $(Expr(:top, :include))($name, x)),
-             :(include(mapexpr::Function, x) = $(Expr(:top, :include))(mapexpr, $name, x)),
-             :(include($path))))
-	m
-end
 
 """ Provides checkbox to toggle full width versus narrow with column for LiveDocs """
 function WidthOverDocs(enabled::Bool=false)  # From PlutoThemes.jl
@@ -55,4 +35,3 @@ function WidthOverDocs(enabled::Bool=false)  # From PlutoThemes.jl
 </script>
 """)
 end
-

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -32,7 +32,7 @@ using Markdown
     end;
 
     @testset "Ingredients" begin
-         @test typeof(ingredients("empty_module.jl")) == Module
+         @test typeof(@ingredients("empty_module.jl")) == Module
     end;
 
 end


### PR DESCRIPTION
Hi! I've just found this package. I'll happily use it instead of copying over the same functions again and again.

This PR replaces `ingredients` by the `@ingredients` macro from PlutoLinks. This has the added benefit that it will automatically re-execute cells when the source file changes.

I guess one could do the same with `WidthOverDocs`, but the link you have in the README is dead. Not sure if that code moved somewhere else.