### PR TITLE
fix typo in `WidthOverDocs`

### DIFF
--- a/src/other.jl
+++ b/src/other.jl
@@ -21,7 +21,7 @@ function ingredients(path::String)
 end
 
 """ Provides checkbox to toggle full width versus narrow with column for LiveDocs """
-function WidthOverDocs(enabled::Bool=false)  # From PlutoThemes.jl
+function WidthOverDocs(wide::Bool=false)  # From PlutoThemes.jl
 	checked = wide ? "checked" : ""
 	init = wide ? "toggle_width(document.getElementById('width-over-livedocs'))" : ""
 	return HTML("""


### PR DESCRIPTION
I don't really get how this function works (I don't speak html) but with this change it at least doesn't error.
