### PR TITLE
Increment Version 

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "PlutoTeachingTools"
 uuid = "661c6b06-c737-4d37-b85c-46df65de6f69"
 authors = ["Eric Ford <ebf11@psu.edu> and contributors"]
-version = "0.2.5"
+version = "0.2.6"
 
 [deps]
 Downloads = "f43a241f-c20a-4ad4-852c-f6b1247861c6"


### PR DESCRIPTION
I noticed the prior changes are not avaible when I am `using PlutoTeachingTools` I noticed it is because a new version has not be published. I would like to use the new features in recent notebooks, if possible.
This PR increments the version so as to publish a new package version to use the new features
## changes since 0.2.5
- add "Answer" box
- fix empty tuple returned by footnotes functions

let me know if there is a different workflow for this (e.g. should I have opened an issue). Or if releases are released differently e.g. every quarter