### PR TITLE
Add A More Flexible TODO() function

### DIFF
--- a/src/computational_thinking.jl
+++ b/src/computational_thinking.jl
@@ -156,7 +156,7 @@ TODO() = TODO_str
 Displays nice TODO graphic inline as an H1 heading (so will show up in PlutoUI's table of contents). 
 Useful for demarcating work-in-progress sections or parts that could be imporved or will be worked on later, etc.
 """
-function TODO(text::String)
+function TODO(text)
 @htl("""
 <div class="todo-tape">
 </div> 

--- a/src/computational_thinking.jl
+++ b/src/computational_thinking.jl
@@ -2,6 +2,7 @@
 using Random # , Distributions # not sure if we need that
 using Markdown
 using LaTeXStrings
+using HypertextLiteral 
 
 export hint, tip, protip, almost, warning_box, question_box, answer_box, danger 
 export correct, still_missing, still_nothing, wrong_type
@@ -150,6 +151,42 @@ correct(text, lang::AbstractLanguage = default_language[]) = correct(;lang, text
 
 TODO_str = html"<span style='display: inline; font-size: 2em; color: purple; font-weight: 900;'>TODO</span>"
 TODO() = TODO_str
+
+"""
+Displays nice TODO graphic inline as an H1 heading (so will show up in PlutoUI's table of contents). 
+Useful for demarcating work-in-progress sections or parts that could be imporved or will be worked on later, etc.
+"""
+function TODO(text::String)
+@htl("""
+<div class="todo-tape">
+</div> 
+<div class="todo-tape-content">
+<h1>&#9888; TODO &#9888;</h1>
+<p>$text</p>
+</div> 
+<div class="todo-tape">
+</div> 
+
+
+<style> 
+div.todo-tape {
+padding: 1rem;
+background: repeating-linear-gradient(
+45deg,
+#FFE41E,
+#FFE41E 12px,
+#141617 12px,
+#141617 24px
+);
+}
+
+div.todo-tape-content {
+padding:1.2rem;
+background-color: white;
+}
+</style>
+""")
+end
 
 # Useful strings for embedding in markdown
 nbsp = html"&nbsp;"


### PR DESCRIPTION
I wanted a better TODO function the current one just displays big `TODO` text in purple. I wanted the ability to have a nice visual  indicator like a under construction sign. Useful in dev and classroom to designate work in progress parts or items that are to-do/"construction needed"/need to be built by students etc.

looks like this in the notebook when called
![image](https://user-images.githubusercontent.com/109242984/222535016-e223fac7-3c16-46a2-a71a-4978d1b69f12.png)

shows up in the table of contents as well 
![image](https://user-images.githubusercontent.com/109242984/222534283-80714104-c369-4089-9a06-c5b6db304f6c.png)

Let me know if there is anything I missed