### PR TITLE
Fix Footnotes Not Working Correctly

### DIFF
--- a/example.jl
+++ b/example.jl
@@ -306,14 +306,12 @@ If you do, the CSS that they provide may not take effect.
 """
 
 # ╔═╡ cb31500f-0cc4-49f0-a338-a75a34c95560
-InlineFootnotesStyleSuperscript()
-#InlineFootnotesStyleBaseline()
-#InlineFootnotesStyleSubscript()
+FootnotesStyleSuperscript()
+#FootnotesStyleBaseline()
+#FootnotesStyleSubscript()
 
 # ╔═╡ f66b3b03-78ee-4eef-a0d6-43f4249d3332
-InlineAndBottomFootnotesNumbered()
-#InlineFootnotesNumbered()
-#BottomFootnotesNumbered()
+FootnotesNumbered()
 
 # ╔═╡ f4201010-71d1-4889-99e7-abb774612a4d
 begin

--- a/example.jl
+++ b/example.jl
@@ -306,12 +306,14 @@ If you do, the CSS that they provide may not take effect.
 """
 
 # ╔═╡ cb31500f-0cc4-49f0-a338-a75a34c95560
-FootnotesStyleSuperscript()
-#FootnotesStyleBaseline()
-#FootnotesStyleSubscript()
+FootnotesInlineStyleSuperscript()
+#FootnotesInlineStyleBaseline()
+#FootnotesInlineStyleSubscript()
 
 # ╔═╡ f66b3b03-78ee-4eef-a0d6-43f4249d3332
 FootnotesNumbered()
+#FootnotesInlineNumbered()
+#FootnotesBottomNumbered()
 
 # ╔═╡ f4201010-71d1-4889-99e7-abb774612a4d
 begin

--- a/src/PlutoTeachingTools.jl
+++ b/src/PlutoTeachingTools.jl
@@ -14,6 +14,6 @@ include("latex.jl")     # provides latexify_md and wrap_tex
 include("aside.jl")     # provides aside
 include("robustlocalresource.jl") # provides RobustLocalResource
 include("other.jl")     # provides WidthOverDocs()
-include("footnotes.jl") # provides InlineAndBottomFootnotesNumbered() and InlineFootnotesStyleSuperscript()
+include("footnotes.jl") # provides FootnotesNumbered() and FootnotesInlineStyleSuperscript()
 
 end # module

--- a/src/footnotes.jl
+++ b/src/footnotes.jl
@@ -180,7 +180,7 @@ a.footnote {
 
 export FootnotesInlineNumbered 
 export FootnotesBottomNumbered 
-export InlineAndBottomFootnotesNumbered
+export FootnotesNumbered
 export FootnotesInlineStyleSuperscript 
 export FootnotesInlineStyleSubscript  
 export FootnotesInlineStyleBaseline 

--- a/src/footnotes.jl
+++ b/src/footnotes.jl
@@ -115,7 +115,7 @@ end
 
 
 
-function BottomFootnotesNumbered()
+function FootnotesBottomNumbered()
 html"""
 <style> 
 pluto-notebook {

--- a/src/footnotes.jl
+++ b/src/footnotes.jl
@@ -140,8 +140,8 @@ end
 function FootnotesNumbered()
 	PlutoUI.combine() do Child
 	@htl("""
-	$(Child(FootnotesBottomNumbered()))
 	$(Child(FootnotesInlineNumbered()))
+	$(Child(FootnotesBottomNumbered()))
 	""")
 	end
 end

--- a/src/footnotes.jl
+++ b/src/footnotes.jl
@@ -1,31 +1,41 @@
 #=
-inpired by discussion and code found here
-
 - https://hub.gke2.mybinder.org/user/fonsp-pluto-on-binder-o5onajv8/pluto/edit?id=f001628e-4bfb-11ed-04d7-892b7e9b1fe3&token=OG86wPs6Tn2cc0wPePWTPw#footnote-what_is_this
 
 - https://github.com/JuliaPluto/PlutoUI.jl/issues/44
 =#
-export FootnotesNumbered
-"""
-Styles footnotes in `Pluto.jl` as numbers 
-"""
-FootnotesNumbered()= html"""
-<script id="footnotes">
+using HypertextLiteral
+using PlutoUI
+
+function FootnotesInlineNumbered()
+html"""
+<script>
 const addNumbersToInlineFootnotes = () => {
+
+
 const inlinefootnotesNodes=document.querySelectorAll("a.footnote")
 const bottomfootnoteNodes=document.getElementsByClassName("footnote-title")
+
+
 const botttomFootnoteTextList=Array.from(bottomfootnoteNodes).map(x=>x.innerText);
+
+
 //get the inline footers inner text so that we can match up with the 
 const inlineFootnoteTextList=Array.from(inlinefootnotesNodes)
 .map(x=>x.innerText)
+
+
 //add square brackets to match the inline footnotes
 const botttomFootnoteTextListWithBrackets=botttomFootnoteTextList.map(x=>"["+x+"]");
+
+
 //find the number which we want to display inline
 var inlineFootnoteTextListWithNumbers = inlineFootnoteTextList
 .map((x,index)=>{
+
 const indexOfBottomFootnote = botttomFootnoteTextListWithBrackets.indexOf(x)
 const indexOfBottomFootnotePlus1 = indexOfBottomFootnote+1
 const element = inlinefootnotesNodes[index]
+
 //modify the element before part depending on if we find a match
 if (indexOfBottomFootnote<0) 
 {//if we don't find a match display an error
@@ -35,9 +45,20 @@ else
 {//if we do add the number and make the label disapear by sizing it to 0px
 	element.setAttribute("data-before","["+indexOfBottomFootnotePlus1+"]")
 }
+
 return indexOfBottomFootnotePlus1
+
 })
+
 }//end of function addNumbersToInlineFootnotes
+
+
+
+
+
+
+
+
 //run everytime "something" is done so that it updates dynamically/reactively
 //2022/10/28
 //all of the below was taken from Table of Contents in PlutoUI 
@@ -65,60 +86,67 @@ const createCellObservers = () => {
 	})
 }
 createCellObservers()
+
 // And one for the notebook's child list, which updates our cell observers:
 const notebookObserver = new MutationObserver(() => {
 	updateCallback()
 	createCellObservers()
 })
 notebookObserver.observe(notebook, {childList: true})
+
 // And finally, an observer for the document.body classList, to make sure that the fotnotz also works when it is loaded during notebook initialization
 const bodyClassObserver = new MutationObserver(updateCallback)
 bodyClassObserver.observe(document.body, {attributeFilter: ["class"]})
-
 </script>
 
-
-
-
-<style> 
-	/*
-	in-line/in-text footnote css styling
-	*/
-	a.footnote {
-		font-size: 0 !important;
-	}
-	a.footnote::before {
-		content: attr(data-before) ;
-		font-size: 10px;
-	}
-
-
-
-	/*
-	bottom-of-page footnote title css styling
-	*/
-	pluto-notebook {
-	counter-reset:  footnote-title;
-	} 
-
-	.footnote-title {
-		font-size: 0 !important;
-	}
-	.footnote-title::before {
-		counter-increment: footnote-title !important;
-		content: "[" counter(footnote-title) "]" !important;
-		font-size: 0.75rem !important;
-	}
+<style>
+a.footnote {
+	font-size: 0 !important;
+}
+a.footnote::before {
+	content: attr(data-before) ;
+	font-size: 10px;
+}
 </style>
 """
+end
 
 
 
-export FootnotesStyleSuperscript 
+function BottomFootnotesNumbered()
+html"""
+<style> 
+pluto-notebook {
+counter-reset:  footnote-title;
+} 
+
+.footnote-title {
+font-size: 0 !important;
+}
+
+.footnote-title::before {
+counter-increment: footnote-title !important;
+content: "[" counter(footnote-title) "]" !important;
+font-size: 0.75rem !important;
+}
+</style>
 """
-Styles in-text/in-line footnotes in `Pluto.jl` as superscript text
-"""
-FootnotesStyleSuperscript()=html"""
+end
+
+
+
+function FootnotesNumbered()
+	PlutoUI.combine() do Child
+	@htl("""
+	$(Child(FootnotesBottomNumbered()))
+	$(Child(FootnotesInlineNumbered()))
+	""")
+	end
+end
+
+
+
+FootnotesInlineStyleSuperscript()=html"""
 <style> 
 a.footnote {
 	vertical-align: super;
@@ -127,11 +155,8 @@ a.footnote {
 """
 
 
-export FootnotesStyleSubscript 
-"""
-Styles in-text/in-line footnotes in `Pluto.jl` as subscript text
-"""
-FootnotesStyleSubscript()=html"""
+
+FootnotesInlineStyleSubscript()=html"""
 <style> 
 a.footnote {
 	vertical-align: sub;
@@ -141,11 +166,7 @@ a.footnote {
 
 
 
-export FootnotesStyleBaseline 
-"""
-Styles in-text/in-line footnotes in `Pluto.jl` as baseline text 
-"""
-FootnotesStyleBaseline()=html"""
+FootnotesInlineStyleBaseline()=html"""
 <style> 
 a.footnote {
 	vertical-align: baseline;
@@ -155,7 +176,11 @@ a.footnote {
 
 
 
- 
-
+export FootnotesInlineNumbered 
+export FootnotesBottomNumbered 
+export InlineAndBottomFootnotesNumbered
+export FootnotesInlineStyleSuperscript 
+export FootnotesInlineStyleSubscript  
+export FootnotesInlineStyleBaseline 
 
 

--- a/src/footnotes.jl
+++ b/src/footnotes.jl
@@ -10,7 +10,7 @@ using PlutoUI
 
 function FootnotesInlineNumbered()
 html"""
-<script>
+<script id="footnotes">
 const addNumbersToInlineFootnotes = () => {
 
 

--- a/src/footnotes.jl
+++ b/src/footnotes.jl
@@ -1,4 +1,6 @@
 #=
+inpired by discussion and code found here
+
 - https://hub.gke2.mybinder.org/user/fonsp-pluto-on-binder-o5onajv8/pluto/edit?id=f001628e-4bfb-11ed-04d7-892b7e9b1fe3&token=OG86wPs6Tn2cc0wPePWTPw#footnote-what_is_this
 
 - https://github.com/JuliaPluto/PlutoUI.jl/issues/44

--- a/src/footnotes.jl
+++ b/src/footnotes.jl
@@ -1,41 +1,31 @@
 #=
-# Code from unamedunknownusername via https://github.com/JuliaPluto/PlutoTeachingTools.jl/pull/19
 inpired by discussion and code found here
 
 - https://hub.gke2.mybinder.org/user/fonsp-pluto-on-binder-o5onajv8/pluto/edit?id=f001628e-4bfb-11ed-04d7-892b7e9b1fe3&token=OG86wPs6Tn2cc0wPePWTPw#footnote-what_is_this
 
 - https://github.com/JuliaPluto/PlutoUI.jl/issues/44
 =#
-using HypertextLiteral
-
-InlineFootnotesNumberedJsString()="""
+export FootnotesNumbered
+"""
+Styles footnotes in `Pluto.jl` as numbers 
+"""
+FootnotesNumbered()= html"""
+<script id="footnotes">
 const addNumbersToInlineFootnotes = () => {
-
-
 const inlinefootnotesNodes=document.querySelectorAll("a.footnote")
 const bottomfootnoteNodes=document.getElementsByClassName("footnote-title")
-
-
 const botttomFootnoteTextList=Array.from(bottomfootnoteNodes).map(x=>x.innerText);
-
-
 //get the inline footers inner text so that we can match up with the 
 const inlineFootnoteTextList=Array.from(inlinefootnotesNodes)
 .map(x=>x.innerText)
-
-
 //add square brackets to match the inline footnotes
 const botttomFootnoteTextListWithBrackets=botttomFootnoteTextList.map(x=>"["+x+"]");
-
-
 //find the number which we want to display inline
 var inlineFootnoteTextListWithNumbers = inlineFootnoteTextList
 .map((x,index)=>{
-
 const indexOfBottomFootnote = botttomFootnoteTextListWithBrackets.indexOf(x)
 const indexOfBottomFootnotePlus1 = indexOfBottomFootnote+1
 const element = inlinefootnotesNodes[index]
-
 //modify the element before part depending on if we find a match
 if (indexOfBottomFootnote<0) 
 {//if we don't find a match display an error
@@ -45,20 +35,9 @@ else
 {//if we do add the number and make the label disapear by sizing it to 0px
 	element.setAttribute("data-before","["+indexOfBottomFootnotePlus1+"]")
 }
-
 return indexOfBottomFootnotePlus1
-
 })
-
 }//end of function addNumbersToInlineFootnotes
-
-
-
-
-
-
-
-
 //run everytime "something" is done so that it updates dynamically/reactively
 //2022/10/28
 //all of the below was taken from Table of Contents in PlutoUI 
@@ -86,121 +65,97 @@ const createCellObservers = () => {
 	})
 }
 createCellObservers()
-
 // And one for the notebook's child list, which updates our cell observers:
 const notebookObserver = new MutationObserver(() => {
 	updateCallback()
 	createCellObservers()
 })
 notebookObserver.observe(notebook, {childList: true})
-
 // And finally, an observer for the document.body classList, to make sure that the fotnotz also works when it is loaded during notebook initialization
 const bodyClassObserver = new MutationObserver(updateCallback)
 bodyClassObserver.observe(document.body, {attributeFilter: ["class"]})
 
-"""
+</script>
 
 
 
-InlineFootnotesNumberedCssString()="""
-a.footnote {
-	font-size: 0 !important;
-}
-a.footnote::before {
-	content: attr(data-before) ;
-	font-size: 10px;
-}
-"""
 
-function InlineFootnotesNumbered()
-	return @htl("""
-	<script id="footnotes">
-	$(InlineFootnotesNumberedJsString())
-	</script>
-	<style> 
-	$(InlineFootnotesNumberedCssString())
-	</style>
-	""")
-end
-
-BottomFootnotesNumberedCssString()="""
-pluto-notebook {
-  counter-reset:  footnote-title;
-} 
-
-.footnote-title {
-	font-size: 0 !important;
-}
-.footnote-title::before {
-	counter-increment: footnote-title !important;
-	content: "[" counter(footnote-title) "]" !important;
-	font-size: 0.75rem !important;
-}
-"""
-
-function BottomFootnotesNumbered()
-	@htl("""
-	<style> 
-	$(BottomFootnotesNumberedCssString())
-	</style>
-	""")
-end
-
-
-function InlineAndBottomFootnotesNumbered() 
-	return @htl("""
-	<script id="footnotes">
-	$(InlineFootnotesNumberedJsString())
-	</script>
-	<style> 
-	$(InlineFootnotesNumberedCssString()*BottomFootnotesNumberedCssString())
-	</style>
-	""")
-end
-
-InlineFootnotesStyleSuperscript()=html"""
 <style> 
+	/*
+	in-line/in-text footnote css styling
+	*/
+	a.footnote {
+		font-size: 0 !important;
+	}
+	a.footnote::before {
+		content: attr(data-before) ;
+		font-size: 10px;
+	}
 
 
+
+	/*
+	bottom-of-page footnote title css styling
+	*/
+	pluto-notebook {
+	counter-reset:  footnote-title;
+	} 
+
+	.footnote-title {
+		font-size: 0 !important;
+	}
+	.footnote-title::before {
+		counter-increment: footnote-title !important;
+		content: "[" counter(footnote-title) "]" !important;
+		font-size: 0.75rem !important;
+	}
+</style>
+"""
+
+
+
+export FootnotesStyleSuperscript 
+"""
+Styles in-text/in-line footnotes in `Pluto.jl` as superscript text
+"""
+FootnotesStyleSuperscript()=html"""
+<style> 
 a.footnote {
 	vertical-align: super;
 }
-
-
 </style>
 """
 
 
-InlineFootnotesStyleSubscript()=html"""
+export FootnotesStyleSubscript 
+"""
+Styles in-text/in-line footnotes in `Pluto.jl` as subscript text
+"""
+FootnotesStyleSubscript()=html"""
 <style> 
-
-
 a.footnote {
 	vertical-align: sub;
 }
-
-
 </style>
 """
 
 
-InlineFootnotesStyleBaseline()=html"""
+
+export FootnotesStyleBaseline 
+"""
+Styles in-text/in-line footnotes in `Pluto.jl` as baseline text 
+"""
+FootnotesStyleBaseline()=html"""
 <style> 
-
-
 a.footnote {
 	vertical-align: baseline;
 }
-
-
 </style>
 """
 
-export InlineFootnotesNumbered 
-export BottomFootnotesNumbered 
-export InlineAndBottomFootnotesNumbered
-export InlineFootnotesStyleSuperscript 
-export InlineFootnotesStyleSubscript  
-export InlineFootnotesStyleBaseline 
+
+
+ 
+
 
 


### PR DESCRIPTION
Footnotes have not been working since we tried to fix the display empty tuple issue - https://github.com/JuliaPluto/PlutoTeachingTools.jl/pull/20

Notice how the numbers don't show up in the example notebook
![image](https://user-images.githubusercontent.com/109242984/230611678-155ad0a5-2559-4968-a3a4-ad617381d620.png)

I decided to abandon the old "cssString" approach and use `PlutoUI.Combine` function which makes things a lot cleaner in my opinion

I also moved the `Inline` and `Bottom` prefix on all the functions so that everything starts with `Footnotes` - which I think helps discoverability