### PR TITLE
Test on 1.11.0-rc

### DIFF
--- a/.github/workflows/Test.yml
+++ b/.github/workflows/Test.yml
@@ -25,7 +25,7 @@ jobs:
             # Without setting this, a failing test cancels all others
             fail-fast: false
             matrix:
-                julia-version: ["1.6", "1", "~1.10.0-0"]
+                julia-version: ["1.6", "1", "pre"]
                 os: [ubuntu-latest]
 
         steps:
@@ -33,10 +33,10 @@ jobs:
             - uses: actions/checkout@v3
 
             # Makes the `julia` command available
-            - uses: julia-actions/setup-julia@v1
+            - uses: julia-actions/setup-julia@v2
               with:
                   version: ${{ matrix.julia-version }}
-            - uses: julia-actions/cache@v1
+            - uses: julia-actions/cache@v2
 
             # 🚗
             - uses: julia-actions/julia-runtest@v1

--- a/.github/workflows/Test.yml
+++ b/.github/workflows/Test.yml
@@ -25,7 +25,7 @@ jobs:
             # Without setting this, a failing test cancels all others
             fail-fast: false
             matrix:
-                julia-version: ["1.6", "1", "pre"]
+                julia-version: ["lts", "1", "pre"]
                 os: [ubuntu-latest]
 
         steps:


### PR DESCRIPTION
you can now run test on the latest pre-release without specifying an explicit version 