### PR TITLE
use `PlutoUI.details` for `Foldable`

### DIFF
--- a/src/PlutoTeachingTools.jl
+++ b/src/PlutoTeachingTools.jl
@@ -6,6 +6,7 @@ using Downloads: download # used in robustlocalresouce.jl
 using PlutoUI: Resource, LocalResource # used in robustlocalresouce.jl
 using PlutoUI: combine # used in footnotes.jl
 using PlutoUI: Select # used in i8n/i8n.jl
+using PlutoUI: details # used in present.jl for Foldable
 using Latexify: latexify # used in latex.jl
 
 using PlutoLinks: @ingredients

--- a/src/present.jl
+++ b/src/present.jl
@@ -6,17 +6,8 @@ function present_button(lang::AbstractLanguage=default_language[])
     htl"<button onclick='present()'>$txt</button>"
 end
 
-struct Foldable{C}
-    title::String
-    content::C
-end
+Foldable(title, content) = details(title, content)
 
-function Base.show(io, mime::MIME"text/html", fld::Foldable)
-    write(io, "<details><summary>$(fld.title)</summary><p>")
-    show(io, mime, fld.content)
-    write(io, "</p></details>")
-    return nothing
-end
 
 struct TwoColumn{L,R}
     left::L


### PR DESCRIPTION
Foldable becomes much more powerful.

Previously:

```julia
Foldable("bla", "bla") ## error: second argument can't be a string
Foldable(md"Some math: ``x \in X``", md"more math: ``n \times n``") ## error: first argument must be a string
```

Now:

<img width="892" alt="image" src="https://github.com/user-attachments/assets/c29d2df3-341e-41c1-9a5a-987b456f7b6b">
