### PR TITLE
Add French translation

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,5 +40,6 @@ If you are using PlutoTeachingTools in a course/workshop and your notebooks are 
 - [jonschumacher](https://github.com/jonschumacher):  Internationalization & German
 - [mathutopia](https://github.com/mathutopia): Chinese
 - [kagalenko-m-b](kagalenko-m-b): Russian
+- [blegat](https://github.com/blegat): French
 - [Several more users](https://github.com/JuliaPluto/PlutoTeachingTools.jl/graphs/contributors)
  

--- a/example.jl
+++ b/example.jl
@@ -41,7 +41,7 @@ md"# [PlutoTeachingTools.jl](https://github.com/JuliaPluto/PlutoTeachingTools.jl
 
 # ╔═╡ 84ccb960-41f8-430d-bd73-a7c0248cfb95
 md"""
-Language for common prompts: $(@bind lang Select(["en"=>"English", "de"=>"German/Deutsch", "es"=>"Spanish/Español", "ru"=>"Russian", "zh"=>"Chinese"]))
+Language for common prompts: $(@bind lang Select(["en"=>"English", "de"=>"German/Deutsch", "es"=>"Spanish/Español", "fr" => "French/Français", "ru"=>"Russian", "zh"=>"Chinese"]))
 """
 
 # ╔═╡ 657c3eea-1ef6-11ed-3e82-5daad2bc19a1
@@ -420,7 +420,7 @@ end
 Markdown.parse("""See also [multi-language support]($mls_link) section below""")
 
 # ╔═╡ ef32d891-0a7a-4803-95ae-a930787c243a
-preferred_text((en=md"Hello", de=md"Hallo", es=md"Hola", ru=md"привет", zh="你好!"))
+preferred_text((en=md"Hello", de=md"Hallo", es=md"Hola", fr=md"Bonjour", ru=md"привет", zh="你好!"))
 
 # ╔═╡ d3762092-e31d-4b96-840a-3939b89f60b7
 tip(
@@ -428,6 +428,7 @@ tip(
         en=md"Remember to add good documentation.",
         de=md"Denken Sie daran, eine gute Dokumentation hinzuzufügen.",
         es=md"Recuerde agregar buena documentación",
+        fr=md"Ne pas oublier d'ajouter une bonne documentation.",
     )),
 )
 

--- a/src/i18n/french.jl
+++ b/src/i18n/french.jl
@@ -4,9 +4,11 @@ using Markdown: @md_str, Code
 using ..PlutoTeachingTools: PlutoTeachingTools, AbstractLanguage
 
 abstract type French <: AbstractLanguage end
-struct FrenchFormal <: French end
-struct FrenchColloquial <: French end
-FrenchFrance = FrenchFormal
+abstract type FrenchFormal <: French end
+abstract type FrenchColloquial <: French end
+struct FrenchBelgiumFormal <: FrenchFormal end
+struct FrenchBelgiumColloquial <: FrenchColloquial end
+FrenchBelgium = FrenchBelgiumColloquial
 
 # computational_thinking.jl
 PlutoTeachingTools.hint_str(lang::Lang) where {Lang<:French} = "Indice"

--- a/src/i18n/french.jl
+++ b/src/i18n/french.jl
@@ -6,6 +6,7 @@ using ..PlutoTeachingTools: PlutoTeachingTools, AbstractLanguage
 abstract type French <: AbstractLanguage end
 struct FrenchFormal <: French end
 struct FrenchColloquial <: French end
+FrenchFrance = FrenchFormal
 
 # computational_thinking.jl
 PlutoTeachingTools.hint_str(lang::Lang) where {Lang<:French} = "Indice"

--- a/src/i18n/french.jl
+++ b/src/i18n/french.jl
@@ -1,0 +1,168 @@
+module PTTFrench
+
+using Markdown: @md_str, Code
+using ..PlutoTeachingTools: PlutoTeachingTools, AbstractLanguage
+
+abstract type French <: AbstractLanguage end
+struct FrenchFormal <: French end
+struct FrenchColloquial <: French end
+
+# computational_thinking.jl
+PlutoTeachingTools.hint_str(lang::Lang) where {Lang<:French} = "Indice"
+PlutoTeachingTools.tip_str(lang::Lang) where {Lang<:French} = "Astuce"
+function PlutoTeachingTools.protip_invite_str(lang::Lang) where {Lang<:French}
+    return "Envie d'en savoir plus?"
+end
+PlutoTeachingTools.protip_boxlabel_str(lang::Lang) where {Lang<:French} = "Astuce Avancée"
+function PlutoTeachingTools.answer_invite_str(lang::Lang) where {Lang<:FrenchFormal}
+    return "Voulez-vous voir la réponse?"
+end
+function PlutoTeachingTools.answer_invite_str(lang::Lang) where {Lang<:FrenchColloquial}
+    return "Veux-tu voir la réponse?"
+end
+PlutoTeachingTools.answer_boxlabel_str(lang::Lang) where {Lang<:French} = "Réponse"
+PlutoTeachingTools.almost_str(lang::Lang) where {Lang<:French} = "Presque!"
+PlutoTeachingTools.warning_box_str(lang::Lang) where {Lang<:French} = "Attention:"
+PlutoTeachingTools.question_box_str(lang::Lang) where {Lang<:French} = "Question:"
+PlutoTeachingTools.danger_str(lang::Lang) where {Lang<:FrenchFormal} = "Méfiez-vous!"
+PlutoTeachingTools.danger_str(lang::Lang) where {Lang<:FrenchColloquial} = "Méfie-toi!"
+PlutoTeachingTools.keyconcept_str(lang::Lang) where {Lang<:French} = "🎯 Concept clé"
+PlutoTeachingTools.still_missing_str(lang::Lang) where {Lang<:French} = "Réponse Manquante"
+function PlutoTeachingTools.still_missing_text_str(lang::Lang) where {Lang<:FrenchFormal}
+    md"Remplacez `missing` par votre réponse."
+end
+function PlutoTeachingTools.still_missing_text_str(lang::Lang) where {Lang<:FrenchColloquial}
+    md"Remplace `missing` par ta réponse."
+end
+PlutoTeachingTools.still_nothing_str(lang::Lang) where {Lang<:French} = "C'est parti!"
+function PlutoTeachingTools.still_nothing_text_str(lang::Lang) where {Lang<:FrenchFormal}
+    md"Remplacez `nothing` par votre réponse."
+end
+function PlutoTeachingTools.still_nothing_text_str(lang::Lang) where {Lang<:FrenchColloquial}
+    md"Remplace `nothing` par ta réponse."
+end
+PlutoTeachingTools.wrong_type_str(lang::Lang) where {Lang<:French} = "Erreur de Type"
+function PlutoTeachingTools.wrong_type_text_str(lang::Lang) where {Lang<:FrenchFormal}
+    md"Vérifiez le type de votre réponse."
+end
+function PlutoTeachingTools.wrong_type_text_str(lang::Lang) where {Lang<:FrenchColloquial}
+    md"Vérifie le type de ta réponse."
+end
+function PlutoTeachingTools.wrong_type_text_str(lang::Lang, var, type) where {Lang<:French}
+    md"Le type de $var devrait être $type"
+end
+PlutoTeachingTools.func_not_defined_str(lang::Lang) where {Lang<:French} = "Oups!"
+function PlutoTeachingTools.func_not_defined_text_str(
+    func_name, lang::Lang
+) where {Lang<:FrenchFormal}
+    fn = Code(string(func_name))
+    md"Vérifiez que vous définissez une fonction appelée **$(fn)**"
+end
+function PlutoTeachingTools.func_not_defined_text_str(
+    func_name, lang::Lang
+) where {Lang<:FrenchColloquial}
+    fn = Code(string(func_name))
+    md"Vérifie que tu définis une fonction appelée **$(fn)**"
+end
+PlutoTeachingTools.var_not_defined_str(lang::Lang) where {Lang<:French} = "Oups!"
+function PlutoTeachingTools.var_not_defined_text_str(
+    variable_name, lang::Lang
+) where {Lang<:FrenchFormal}
+    vn = Code(string(variable_name))
+    md"Vérifiez que vous définissez une variable appelée **$(vn)**"
+end
+function PlutoTeachingTools.var_not_defined_text_str(
+    variable_name, lang::Lang
+) where {Lang<:FrenchColloquial}
+    vn = Code(string(variable_name))
+    md"Vérifie que tu définis une variable appelée **$(vn)**"
+end
+function PlutoTeachingTools.keep_working_str(lang::Lang) where {Lang<:French}
+    return "Encore un effort!"
+end
+function PlutoTeachingTools.keep_working_text_str(lang::Lang) where {Lang<:French}
+    md"La réponse n'est pas tout à fait juste."
+end
+function PlutoTeachingTools.keep_working_update_str(var, lang::Lang) where {Lang<:FrenchFormal}
+    md"Vérifiez de mettre à jour la cellule en assignant une valeur à $var."
+end
+function PlutoTeachingTools.keep_working_update_str(var, lang::Lang) where {Lang<:FrenchColloquial}
+    md"Vérifie de mettre à jour la cellule en assignant une valeur à $var."
+end
+function PlutoTeachingTools.yays(lang::Lang) where {Lang<:French}
+    return [
+        md"Génial!",
+        md"Parfait ❤",
+        md"Génial! 🎉",
+        md"Bien joué!",
+        md"Continue comme ça!",
+        md"Bon travail!",
+        md"Impressionnant!",
+        md"C'est la bonne réponse!",
+        md"Passons à la partie suivante.",
+    ]
+end
+PlutoTeachingTools.correct_str(lang::Lang) where {Lang<:French} = "Bien joué!"
+PlutoTeachingTools.todo_str(lang::Lang) where {Lang<:French} = "À FAIRE"
+
+function PlutoTeachingTools.check_type_isa_missing_text_str(
+    sym, lang::Lang
+) where {Lang<:French}
+    md"La variable $sym est encore assignée à missing."
+end
+function PlutoTeachingTools.check_type_isa_wrong_type_text_str(
+    sym, lang::Lang
+) where {Lang<:French}
+    return "Le type de $sym n'est pas correct.  Il devrait être <: "
+end
+function PlutoTeachingTools.check_type_isa_wrong_type_one_of_text_str(
+    lang::Lang
+) where {Lang<:French}
+    return "un de"
+end
+function PlutoTeachingTools.check_type_isa_wrong_type_or_text_str(
+    lang::Lang
+) where {Lang<:French}
+    return "ou"
+end
+function PlutoTeachingTools.check_type_isa_not_missing_text_str(
+    sym, lang::Lang
+) where {Lang<:French}
+    md"$sym a le type correct."
+end
+function PlutoTeachingTools.check_type_isa_type_error_str(
+    sym, lang::Lang
+) where {Lang<:French}
+    return "Erreur de Type"
+end
+
+function PlutoTeachingTools.check_type_eq_missing_text_str(
+    sym, lang::Lang
+) where {Lang<:French}
+    md"La variable $sym est encore assignée à missing."
+end
+function PlutoTeachingTools.check_type_eq_wrong_type_single_text_str(
+    sym, type, lang::Lang
+) where {Lang<:French}
+    return "Le type de $sym devrait être $type."
+end
+function PlutoTeachingTools.check_type_eq_wrong_type_multi_text_str(
+    sym, lang::Lang
+) where {Lang<:French}
+    return "Le type de $sym devrait faire partie de "
+end
+function PlutoTeachingTools.check_type_eq_type_error_str(lang::Lang) where {Lang<:French}
+    return "Erreur de Type"
+end
+function PlutoTeachingTools.check_type_eq_correct_str(sym, lang::Lang) where {Lang<:French}
+    md"$sym a le type correct."
+end
+
+# other.jl
+PlutoTeachingTools.full_width_mode_str(lang::Lang) where {Lang<:French} = "Mode Pleine Largeur"
+
+# present.jl
+PlutoTeachingTools.present_str(lang::Lang) where {Lang<:French} = "présentation"
+PlutoTeachingTools.present_mode_str(lang::Lang) where {Lang<:French} = "Mode Présentation"
+
+end

--- a/src/i18n/i18n.jl
+++ b/src/i18n/i18n.jl
@@ -136,6 +136,8 @@ end
 # Language Options
 include("english.jl")
 import .PTTEnglish: EnglishUS
+include("french.jl")
+import .PTTFrench: FrenchFormal, FrenchColloquial
 include("german.jl")
 import .PTTGerman: GermanGermany, GermanGermanyFormal, GermanGermanyColloquial
 include("russian.jl")
@@ -149,6 +151,10 @@ const languages_registered = Ref{Dict{String,AbstractLanguage}}(
     Dict(
         "en" => EnglishUS(),
         "en_us" => EnglishUS(),
+        "fr" => FrenchFrance(),
+        "fr_fr" => FrenchFrance(),
+        "fr_colloq" => FrenchColloquial(),
+        "fr_formal" => FrenchFormal(),
         "de" => GermanGermany(),
         "de_colloq" => GermanGermanyColloquial(),
         "de_formal" => GermanGermanyFormal(),
@@ -169,6 +175,9 @@ const languages_registered = Ref{Dict{String,AbstractLanguage}}(
 const language_codes_registered = Ref{Dict{AbstractLanguage,Vector{String}}}(
     Dict(
         EnglishUS() => ["en", "en_us"],
+        FrenchFrance() => ["fr", "fr_fr"],
+        FrenchColloquial() => ["fr_colloq", "fr_colloq"],
+        FrenchFormal() => ["fr_formal", "fr_formal"],
         GermanGermany() => ["de", "de_de"],
         GermanGermanyColloquial() => ["de_colloq", "de_de_colloq"],
         GermanGermanyFormal() => ["de_formal", "de_de_formal"],
@@ -181,6 +190,7 @@ const language_codes_registered = Ref{Dict{AbstractLanguage,Vector{String}}}(
 
 select_lang_dropdown = Select([
     "en" => "English",
+    "fr" => "French/France",
     "de" => "German/Deutsch",
     "es" => "Spanish/Español",
     "ru" => "Russian",
@@ -220,6 +230,8 @@ end
 function get_language_old(str::AbstractString)
     if contains(str, r"^en")
         EnglishUS()
+    elseif contains(str, r"^fr")
+        FrenchFrance()
     elseif contains(str, r"^de")
         GermanGermany()
     elseif contains(str, r"^es")

--- a/src/i18n/i18n.jl
+++ b/src/i18n/i18n.jl
@@ -151,10 +151,12 @@ const languages_registered = Ref{Dict{String,AbstractLanguage}}(
     Dict(
         "en" => EnglishUS(),
         "en_us" => EnglishUS(),
-        "fr" => FrenchFrance(),
-        "fr_fr" => FrenchFrance(),
-        "fr_colloq" => FrenchColloquial(),
-        "fr_formal" => FrenchFormal(),
+        "fr" => FrenchBelgium(),
+        "fr_colloq" => FrenchBelgiumColloquial(),
+        "fr_formal" => FrenchBelgiumFormal(),
+        "fr_be" => FrenchBelgium(),
+        "fr_be_colloq" => FrenchBelgiumColloquial(),
+        "fr_be_formal" => FrenchBelgiumFormal(),
         "de" => GermanGermany(),
         "de_colloq" => GermanGermanyColloquial(),
         "de_formal" => GermanGermanyFormal(),
@@ -175,9 +177,9 @@ const languages_registered = Ref{Dict{String,AbstractLanguage}}(
 const language_codes_registered = Ref{Dict{AbstractLanguage,Vector{String}}}(
     Dict(
         EnglishUS() => ["en", "en_us"],
-        FrenchFrance() => ["fr", "fr_fr"],
-        FrenchColloquial() => ["fr_colloq", "fr_colloq"],
-        FrenchFormal() => ["fr_formal", "fr_formal"],
+        FrenchBelgium() => ["fr", "fr_be"],
+        FrenchColloquial() => ["fr_colloq", "fr_be_colloq"],
+        FrenchFormal() => ["fr_formal", "fr_be_formal"],
         GermanGermany() => ["de", "de_de"],
         GermanGermanyColloquial() => ["de_colloq", "de_de_colloq"],
         GermanGermanyFormal() => ["de_formal", "de_de_formal"],
@@ -190,7 +192,7 @@ const language_codes_registered = Ref{Dict{AbstractLanguage,Vector{String}}}(
 
 select_lang_dropdown = Select([
     "en" => "English",
-    "fr" => "French/France",
+    "fr" => "French/Belgium",
     "de" => "German/Deutsch",
     "es" => "Spanish/Español",
     "ru" => "Russian",
@@ -231,7 +233,7 @@ function get_language_old(str::AbstractString)
     if contains(str, r"^en")
         EnglishUS()
     elseif contains(str, r"^fr")
-        FrenchFrance()
+        FrenchBelgium()
     elseif contains(str, r"^de")
         GermanGermany()
     elseif contains(str, r"^es")

--- a/src/i18n/i18n.jl
+++ b/src/i18n/i18n.jl
@@ -137,7 +137,7 @@ end
 include("english.jl")
 import .PTTEnglish: EnglishUS
 include("french.jl")
-import .PTTFrench: FrenchFormal, FrenchColloquial
+import .PTTFrench: FrenchFormal, FrenchColloquial, FrenchBelgium, FrenchBelgiumFormal, FrenchBelgiumColloquial
 include("german.jl")
 import .PTTGerman: GermanGermany, GermanGermanyFormal, GermanGermanyColloquial
 include("russian.jl")

--- a/src/i18n/i18n.jl
+++ b/src/i18n/i18n.jl
@@ -178,8 +178,8 @@ const language_codes_registered = Ref{Dict{AbstractLanguage,Vector{String}}}(
     Dict(
         EnglishUS() => ["en", "en_us"],
         FrenchBelgium() => ["fr", "fr_be"],
-        FrenchColloquial() => ["fr_colloq", "fr_be_colloq"],
-        FrenchFormal() => ["fr_formal", "fr_be_formal"],
+        FrenchBelgiumColloquial() => ["fr_colloq", "fr_be_colloq"],
+        FrenchBelgiumFormal() => ["fr_formal", "fr_be_formal"],
         GermanGermany() => ["de", "de_de"],
         GermanGermanyColloquial() => ["de_colloq", "de_de_colloq"],
         GermanGermanyFormal() => ["de_formal", "de_de_formal"],

--- a/src/i18n/i18n.jl
+++ b/src/i18n/i18n.jl
@@ -137,7 +137,7 @@ end
 include("english.jl")
 import .PTTEnglish: EnglishUS
 include("french.jl")
-import .PTTFrench: FrenchFormal, FrenchColloquial, FrenchBelgium, FrenchBelgiumFormal, FrenchBelgiumColloquial
+import .PTTFrench: FrenchBelgium, FrenchBelgiumFormal, FrenchBelgiumColloquial
 include("german.jl")
 import .PTTGerman: GermanGermany, GermanGermanyFormal, GermanGermanyColloquial
 include("russian.jl")


### PR DESCRIPTION
In french, there are two translations of the singular "you". The polite/formal translation is "vous" and the informal one is "tu".
I created `FrenchFormal` that uses "vous" and `FrenchColloquial` that uses "tu"