### PR TITLE
computational thinking boxes: convert string to markdown automatically as box content

### DIFF
--- a/src/computational_thinking.jl
+++ b/src/computational_thinking.jl
@@ -1,6 +1,9 @@
+import Markdown
+
+
 
 text_to_content(x) = x
-text_to_content(x::String) = Markdown.parse(x)
+text_to_content(x::String) = @static(isdefined(Markdown, :parse) ? getfield(Markdown, :parse)(x) : x)
 
 
 "Hint box with arguement as text."
@@ -156,7 +159,7 @@ end
 function keep_working_if_var_contains_substr(
     var::Symbol, str::MD, substr::String, lang::AbstractLanguage=default_language[]
 )
-    return keep_working_if_var_contains_substr(var, Markdown.plain(str), substr, lang)
+    return keep_working_if_var_contains_substr(var, @static(isdefined(Markdown, :plain) ? getfield(Markdown, :plain)(str) : str), substr, lang)
 end
 
 type_isa(var, t::Union{Type,Vector{Type},Vector{DataType}}) = (any(typeof(var) .<: t))

--- a/src/computational_thinking.jl
+++ b/src/computational_thinking.jl
@@ -1,4 +1,3 @@
-import Markdown
 
 text_to_content(x) = x
 text_to_content(x::String) = Markdown.parse(x)

--- a/src/computational_thinking.jl
+++ b/src/computational_thinking.jl
@@ -1,12 +1,17 @@
+import Markdown
+
+text_to_content(x) = x
+text_to_content(x::String) = Markdown.parse(x)
+
 
 "Hint box with arguement as text."
 function hint(text, lang::AbstractLanguage=default_language[])
-    return MD(Admonition("hint", hint_str(lang), [text]))
+    return MD(Admonition("hint", hint_str(lang), [text_to_content(text)]))
 end
 
 "Tip box with arguement as text."
 function tip(text, lang::AbstractLanguage=default_language[])
-    return MD(Admonition("tip", tip_str(lang), [text]))
+    return MD(Admonition("tip", tip_str(lang), [text_to_content(text)]))
 end
 
 "Tip box with arguement as text."
@@ -16,7 +21,7 @@ function protip(
     invite=protip_invite_str(lang),
     boxlabel=protip_boxlabel_str(lang),
 )
-    return Foldable(invite, MD(Admonition("tip", boxlabel, [text])))
+    return Foldable(invite, MD(Admonition("tip", boxlabel, [text_to_content(text)])))
 end
 function protip(
     text,
@@ -34,7 +39,7 @@ function answer_box(
     invite=answer_invite_str(lang),
     boxlabel=answer_boxlabel_str(lang),
 )
-    return Foldable(invite, MD(Admonition("answer", boxlabel, [text])))
+    return Foldable(invite, MD(Admonition("answer", boxlabel, [text_to_content(text)])))
 end
 function answer_box(
     text,
@@ -47,34 +52,34 @@ end
 
 "Admonition box labeled a warning with arguement as text."
 function almost(text, lang::AbstractLanguage=default_language[])
-    return MD(Admonition("warning", almost_str(lang), [text]))
+    return MD(Admonition("warning", almost_str(lang), [text_to_content(text)]))
 end
 
 "Warning box with arguement as text."
 function warning_box(text, lang::AbstractLanguage=default_language[])
-    return MD(Admonition("warning", warning_box_str(lang), [text]))
+    return MD(Admonition("warning", warning_box_str(lang), [text_to_content(text)]))
 end
 
 "Question box with arguement as text."
 function question_box(text, lang::AbstractLanguage=default_language[])
-    return MD(Admonition("question", question_box_str(lang), [text]))
+    return MD(Admonition("question", question_box_str(lang), [text_to_content(text)]))
 end
 
 "Key concept box with concept name and description as input arguments."
 function keyconcept(concept, text, lang::AbstractLanguage=default_language[])
-    return MD(Admonition("key-concept", keyconcept_str(lang), [md"**$concept**", text]))
+    return MD(Admonition("key-concept", keyconcept_str(lang), [md"**$concept**", text_to_content(text)]))
 end
 
 "Danger box with arguement as text."
 function danger(text, lang::AbstractLanguage=default_language[])
-    return MD(Admonition("danger", danger_str(lang), [text]))
+    return MD(Admonition("danger", danger_str(lang), [text_to_content(text)]))
 end
 
 "Admonition box with reminder to replace missing."
 function still_missing(;
     lang::AbstractLanguage=default_language[], text=still_missing_text_str(lang)
 )
-    return MD(Admonition("warning", still_missing_str(lang), [text]))
+    return MD(Admonition("warning", still_missing_str(lang), [text_to_content(text)]))
 end
 still_missing(text, lang::AbstractLanguage=default_language[]) = still_missing(; lang, text)
 
@@ -82,7 +87,7 @@ still_missing(text, lang::AbstractLanguage=default_language[]) = still_missing(;
 function still_nothing(;
     lang::AbstractLanguage=default_language[], text=still_nothing_text_str(lang)
 )
-    return MD(Admonition("warning", still_nothing_str(lang), [text]))
+    return MD(Admonition("warning", still_nothing_str(lang), [text_to_content(text)]))
 end
 still_nothing(text, lang::AbstractLanguage=default_language[]) = still_nothing(; lang, text)
 
@@ -96,7 +101,7 @@ function wrong_type(
     lang::AbstractLanguage=default_language[];
     text=wrong_type_text_str(lang, var, type),
 )
-    return MD(Admonition("danger", wrong_type_str(lang), [text]))
+    return MD(Admonition("danger", wrong_type_str(lang), [text_to_content(text)]))
 end
 
 "Admonition box with reminder that function name passed is not defined."
@@ -130,7 +135,7 @@ end
 function keep_working(;
     lang::AbstractLanguage=default_language[], text=keep_working_text_str(lang)
 )
-    return MD(Admonition("danger", keep_working_str(lang), [text]))
+    return MD(Admonition("danger", keep_working_str(lang), [text_to_content(text)]))
 end
 keep_working(text, lang::AbstractLanguage=default_language[]) = keep_working(; lang, text);
 
@@ -220,7 +225,7 @@ end
 
 "Box with random positive message."
 function correct(; lang::AbstractLanguage=default_language[], text=rand(yays(lang)))
-    return MD(Admonition("correct", correct_str(lang), [text]))
+    return MD(Admonition("correct", correct_str(lang), [text_to_content(text)]))
 end
 correct(text, lang::AbstractLanguage=default_language[]) = correct(; lang, text)
 


### PR DESCRIPTION
To prevent the `"` quotes in this case:

<img width="1942" height="682" alt="image" src="https://github.com/user-attachments/assets/8cb6dc3b-9136-423d-bb4b-214848e4e420" />
