### PR TITLE
New macro `widemath"""` to render a very big latex equation

### DIFF
--- a/src/PlutoTeachingTools.jl
+++ b/src/PlutoTeachingTools.jl
@@ -1,5 +1,6 @@
 module PlutoTeachingTools
 
+import PlutoUI
 using PlutoUI.ExperimentalLayout: Div
 using Markdown: @md_str, MD, Admonition, LaTeX
 using HypertextLiteral: @htl, @htl_str
@@ -45,6 +46,7 @@ export RobustLocalResource
 
 include("other.jl")
 export WidthOverDocs
+export @widemath_str
 export confetti
 
 include("footnotes.jl")

--- a/src/PlutoTeachingTools.jl
+++ b/src/PlutoTeachingTools.jl
@@ -37,6 +37,7 @@ export ChooseDisplayMode # combines present_button and WidthOverDocs
 
 include("latex.jl")
 export latexify_md, wrap_tex
+export @widemath_str
 
 include("aside.jl")
 export aside, set_aside_width
@@ -46,7 +47,6 @@ export RobustLocalResource
 
 include("other.jl")
 export WidthOverDocs
-export @widemath_str
 export confetti
 
 include("footnotes.jl")

--- a/src/latex.jl
+++ b/src/latex.jl
@@ -20,3 +20,27 @@ begin
 		))
 end
 =#
+
+
+
+"""
+Render LaTeX math text in an extra wide cell. This uses [PlutoUI.WideCell](https://featured.plutojl.org/basic/plutoui.jl#WideCell) to get an extra wide cell, and any content that does fit becomes scrollable: you can scroll the equation to reveal hidden parts.
+
+# Example
+
+```julia
+widemath""\"
+\\sqrt{some very long equation that does not fit in the screen normally} +
+\\sqrt{some very long equation that does not fit in the screen normally} +
+\\sqrt{some very long equation that does not fit in the screen normally}
+"\""
+```
+"""
+macro widemath_str(s)
+	f(x) = Div([x]; style="min-width: max-content;") |> PlutoUI.WideCell
+	LaTeX(s) |> MD |> f
+end
+
+
+
+

--- a/src/other.jl
+++ b/src/other.jl
@@ -53,7 +53,7 @@ widemath""\"
 ```
 """
 macro widemath_str(s)
-	f(x) = PlutoUI.ExperimentalLayout.Div([x]; style="min-width: max-content;") |> PlutoUI.WideCell
+	f(x) = Div([x]; style="min-width: max-content;") |> PlutoUI.WideCell
 	:(Markdown.parse("```math\n$($(esc(s)))\n```") |> $f)
 end
 

--- a/src/other.jl
+++ b/src/other.jl
@@ -38,6 +38,26 @@ function WidthOverDocs(
    """)
 end
 
+
+"""
+Render LaTeX math text in an extra wide cell. This uses [PlutoUI.WideCell](https://featured.plutojl.org/basic/plutoui.jl#WideCell) to get an extra wide cell, and any content that does fit becomes scrollable: you can scroll the equation to reveal hidden parts.
+
+# Example
+
+```julia
+widemath""\"
+\\sqrt{some very long equation that does not fit in the screen normally} +
+\\sqrt{some very long equation that does not fit in the screen normally} +
+\\sqrt{some very long equation that does not fit in the screen normally}
+"\""
+```
+"""
+macro widemath_str(s)
+	f(x) = PlutoUI.ExperimentalLayout.Div([x]; style="min-width: max-content;") |> PlutoUI.WideCell
+	:(Markdown.parse("```math\n$($(esc(s)))\n```") |> $f)
+end
+
+
 """
 Display a full-screen confetti animation! The confetti will disappear automatically, and it will be fired every time the cell is re-run.
 

--- a/src/other.jl
+++ b/src/other.jl
@@ -39,24 +39,6 @@ function WidthOverDocs(
 end
 
 
-"""
-Render LaTeX math text in an extra wide cell. This uses [PlutoUI.WideCell](https://featured.plutojl.org/basic/plutoui.jl#WideCell) to get an extra wide cell, and any content that does fit becomes scrollable: you can scroll the equation to reveal hidden parts.
-
-# Example
-
-```julia
-widemath""\"
-\\sqrt{some very long equation that does not fit in the screen normally} +
-\\sqrt{some very long equation that does not fit in the screen normally} +
-\\sqrt{some very long equation that does not fit in the screen normally}
-"\""
-```
-"""
-macro widemath_str(s)
-	f(x) = Div([x]; style="min-width: max-content;") |> PlutoUI.WideCell
-	:(Markdown.parse("```math\n$($(esc(s)))\n```") |> $f)
-end
-
 
 """
 Display a full-screen confetti animation! The confetti will disappear automatically, and it will be fired every time the cell is re-run.


### PR DESCRIPTION
As a workaround for https://github.com/fonsp/Pluto.jl/issues/3298



<img width="1098" height="360" alt="Scherm­afbeelding 2025-07-31 om 16 17 25" src="https://github.com/user-attachments/assets/7ffca0f4-151a-4098-809f-83bd7b8f0117" />
