### PR TITLE
WCAG 2.1 AA accessibility fixes 

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ Math from computation, math with computation (Spring 2021)](https://computationa
 See the **[example notebook](https://juliapluto.github.io/PlutoTeachingTools.jl/example.html)** for functions provided.
 Several functions have optional arguments that aren't (yet?) demonstrated in the example notebook.
 
+See [accessibility.md](accessibility.md) for the WCAG 2.1 AA accessibility fixes applied to this package's output and any compatibility notes for existing notebooks.
+
 Others are encouraged to improve and/or contribute new functions that are of value to other educators (in either formal or informal settings).  Pull Requests welcome, but please be patient when we are slow to review/merge PRs.
 
 # Other useful packages for Pluto notebook tutorials

--- a/accessibility.md
+++ b/accessibility.md
@@ -1,0 +1,119 @@
+# Accessibility
+
+This document describes the WCAG 2.1 Level AA accessibility fixes made to PlutoTeachingTools.jl,
+what changed under the hood, and what (if anything) that means for existing notebooks.
+
+Scope: this covers markup and styling that PlutoTeachingTools.jl itself generates. Pluto.jl's
+editor chrome and notebook UI are out of scope (see [Pluto.jl](https://github.com/fonsp/Pluto.jl)).
+
+## For notebook authors
+
+- No action is required for typical usage (calling these functions and displaying the result).
+- If you post-process the output of `correct`, `keep_working`, `still_missing`, `still_nothing`,
+  `wrong_type`, or any admonition-producing function (e.g. extracting plain text, checking its
+  type, or splicing it into another `Markdown.MD` and later walking `.content`), see the
+  compatibility notes above.
+- When choosing a custom `color` for `section_outline`, check it for contrast against both light
+  and dark backgrounds after mixing with black/white.
+
+## Summary of changes
+
+| Function(s) | WCAG criterion | Fix |
+|---|---|---|
+| `correct`, `keep_working`, `still_missing`, `still_nothing`, `wrong_type` | 4.1.3 Status Messages | Output wrapped in `role="status" aria-live="polite" aria-atomic="true"` so screen readers announce feedback as it appears. |
+| `hint`, `tip`, `almost`, `warning_box`, `question_box`, `keyconcept`, `danger`, `func_not_defined`, `var_not_defined`, `protip`, `answer_box`, and the boxes above | 3.1.2 Language of Parts | Localized admonition titles wrapped in `lang="xx"` (via new `get_language_code(lang)` in `src/i18n/i18n.jl`) so assistive technology uses the correct voice for the notebook's selected language. |
+| `blockquote` | 1.4.3 Contrast (Minimum) | Border and quote-mark color changed from hardcoded `#ccc` to `color-mix(in srgb, currentColor 40%, transparent)`, which tracks the current theme's text color instead of failing contrast in dark mode. |
+| `section_outline` | 1.4.3 Contrast (Minimum) | Documentation only — see [Custom colors in `section_outline`](#custom-colors-in-section_outline) below. |
+| `Columns`, `TwoColumn`, `ThreeColumn`, `TwoColumnWideLeft`, `TwoColumnWideRight` | 1.4.10 Reflow | Columns now stack into a single column below a 600px viewport width instead of staying in a fixed-percentage row that becomes unreadably narrow. |
+| `TODO` | 1.1.1 Non-text Content | Decorative warning-sign glyphs wrapped in `<span aria-hidden="true">` so screen readers don't announce them. |
+| `blockquote` | 1.1.1 Non-text Content | Quote marks moved from CSS `content: open-quote`/`close-quote` (inconsistent screen reader behavior) to real `<span aria-hidden="true">` text. |
+| `ChooseDisplayMode`, `WidthOverDocs` | 2.4.7 Focus Visible | Checkboxes now show a `:focus-visible` outline for keyboard navigation. |
+| `aside` | 1.3.1 Info and Relationships | Added `aria-label="Aside"`, and a docstring note that `aside` content should be supplementary/non-critical (see below). |
+
+## Compatibility notes
+
+None of the above changed any function's **signature** — every function still takes the same
+positional/keyword arguments it did before. Existing notebooks that just call these functions and
+display the result work unchanged. A few things did change under the hood, and matter only if you
+do something more advanced than displaying the output directly:
+
+### Return type change: `correct`, `keep_working`, `still_missing`, `still_nothing`, `wrong_type`
+
+These five functions used to return a `Markdown.MD` object. They now return an HTML object (built
+with `HypertextLiteral.@htl`) so the ARIA live-region wrapper can be applied. This renders
+identically in Pluto or any browser, but:
+
+- `Markdown.plain(x)`, `Markdown.html(x)`, or other direct `Markdown.*` calls on the returned
+  value will no longer produce clean plain-text/Markdown output — they'll fall back to printing
+  the raw HTML string. This matters if you export a notebook's admonition text to plain text (e.g.
+  for a non-browser transcript), or use these functions outside Pluto in a REPL/terminal.
+- Splicing the result into a larger `Markdown.MD(...)` document (e.g.
+  `Markdown.MD(tip("a"), correct())`) still works for display purposes, but the `.content` element
+  contributed by these five functions is no longer a `Markdown.Admonition` — code that walks
+  `.content` expecting `Admonition` objects will see the new HTML type instead.
+- `isa(x, Markdown.MD)` checks on the output of these five specific functions will now be `false`.
+
+The other admonition functions (`hint`, `tip`, `almost`, `warning_box`, `question_box`,
+`keyconcept`, `danger`, `func_not_defined`, `var_not_defined`, `protip`, `answer_box`) still return
+`Markdown.MD` (so `isa(x, Markdown.MD)` still holds), but their `.content` is now the HTML-wrapped
+admonition rather than a bare `Markdown.Admonition`, so the same plain-text/`.content`-inspection
+caveat applies to them too.
+
+### `Columns` / `TwoColumn` / `ThreeColumn` / `TwoColumnWideLeft` / `TwoColumnWideRight`
+
+These used to return a `PlutoUI.ExperimentalLayout.Div`. They now return an `@htl`-wrapped object
+(so a scoped `<style>` block can be emitted alongside the row) and stack to one column below
+600px. Visual layout at normal widths is unchanged, and passing the result directly to Pluto for
+display works as before. If you were composing the result further with
+`PlutoUI.ExperimentalLayout` combinators expecting a `Div`/`Node`, that composition may no longer
+apply cleanly, since the return value is no longer a bare `Div`.
+
+### Custom colors in `section_outline`
+
+`section_outline`'s `color` keyword is mixed with black (light theme) or white (dark theme) via
+CSS `color-mix()` to derive the text color, rather than used directly. This was already true
+before this review — it isn't a new behavior — but it means a light `color` (e.g. `"yellow"`,
+`"lime"`) can still produce low-contrast text against a light background, and a dark `color` can do
+the same against a dark background. The package cannot verify contrast for an arbitrary
+user-supplied CSS color string, so choose one that stays legible after mixing in both themes; see
+[WCAG 1.4.3](https://www.w3.org/WAI/WCAG21/Understanding/contrast-minimum.html).
+
+### Browser support for `color-mix()`
+
+`blockquote` and `section_outline` both rely on the CSS `color-mix()` function (`blockquote`'s use
+is new as of this review). It's supported in current Chrome/Edge, Firefox, and Safari (roughly
+2023 or later), which covers Pluto's typical embedded browser environment. In an older or
+unsupported browser, the declaration is simply ignored, so borders/text fall back to their
+browser-default color rather than causing an error — a graceful but visually different
+degradation.
+
+### Admonition title/body contrast — fixed upstream in Pluto.jl, not here
+
+An earlier version of this package shipped a `!important` CSS override (`admonition_wcag_colors_style`)
+to fix admonition title/body contrast, because Pluto/Julia's `Markdown.html(::Markdown.Admonition)`
+output has no wrapping class or `id` this package controls — only the shared `.admonition.<category>`
+markup — so a downstream per-package CSS override had to fight Pluto's own higher-specificity
+selectors (`pluto-output div.admonition.<category>`) for `hint`/`warning`/`danger`, and would have
+been silently stripped whenever a notebook is viewed via Pluto's `sanitize_html` "safe preview" path
+(which runs cell HTML output through `DOMPurify` with `FORBID_TAGS: ["style"]`).
+
+Rather than maintain that fragile override, the root cause — Pluto's own light-theme admonition
+colors failing AA contrast, and two of its dark-theme body backgrounds failing/marginal — was fixed
+directly in Pluto.jl itself (see https://github.com/fonsp/Pluto.jl, theme files
+`frontend/themes/{light,dark}.css`). This fixes the problem for every Pluto user and any package
+that emits `Markdown.Admonition` output, not just this one, and doesn't depend on a downstream
+override surviving Pluto's CSS cascade or its sanitizer. Once that fix is merged and released,
+notebooks using a Pluto version with the fix get correct-contrast admonitions automatically; no
+action is needed in this package. If you're on an older Pluto release without the fix, admonition
+title/body contrast for some categories may still fail AA — that's a Pluto.jl issue, not something
+this package can reliably override.
+
+### `aside` and reading order
+
+`aside` renders an `<aside>` element with absolute CSS positioning so it floats beside the main
+content for sighted readers. Because of that positioning, assistive technology walking the page in
+linear reading order may not encounter it where a sighted reader would expect (though it remains
+reachable via a landmarks list, now labeled `aria-label="Aside"`). Content passed to `aside` should
+be supplementary/non-critical — don't put anything there that a reader needs in order to follow the
+main flow of the notebook.
+

--- a/accessibility.md
+++ b/accessibility.md
@@ -87,19 +87,10 @@ unsupported browser, the declaration is simply ignored, so borders/text fall bac
 browser-default color rather than causing an error — a graceful but visually different
 degradation.
 
-### Admonition title/body contrast — fixed upstream in Pluto.jl, not here
+### Admonition title/body contrast — PR submitted upstream for Pluto.jl, not here
 
-An earlier version of this package shipped a `!important` CSS override (`admonition_wcag_colors_style`)
-to fix admonition title/body contrast, because Pluto/Julia's `Markdown.html(::Markdown.Admonition)`
-output has no wrapping class or `id` this package controls — only the shared `.admonition.<category>`
-markup — so a downstream per-package CSS override had to fight Pluto's own higher-specificity
-selectors (`pluto-output div.admonition.<category>`) for `hint`/`warning`/`danger`, and would have
-been silently stripped whenever a notebook is viewed via Pluto's `sanitize_html` "safe preview" path
-(which runs cell HTML output through `DOMPurify` with `FORBID_TAGS: ["style"]`).
-
-Rather than maintain that fragile override, the root cause — Pluto's own light-theme admonition
-colors failing AA contrast, and two of its dark-theme body backgrounds failing/marginal — was fixed
-directly in Pluto.jl itself (see https://github.com/fonsp/Pluto.jl, theme files
+Pluto's own admonition colors were failing AA contrast requirements. I PR was submitted
+directly to Pluto.jl itself (see https://github.com/fonsp/Pluto.jl, theme files
 `frontend/themes/{light,dark}.css`). This fixes the problem for every Pluto user and any package
 that emits `Markdown.Admonition` output, not just this one, and doesn't depend on a downstream
 override surviving Pluto's CSS cascade or its sanitizer. Once that fix is merged and released,

--- a/example.jl
+++ b/example.jl
@@ -32,6 +32,12 @@ end
 # ╔═╡ dee4aa68-e5eb-4a8a-869f-867e61de5ec5
 using PlutoUI    # Provides widgets like Select
 
+# ╔═╡ ec6b46eb-8051-4ff8-a374-8baa51717f88
+md"""
+!!! info "Accessibility improvements (unreleased)"
+	This version of the package includes fixes from a WCAG 2.1 AA accessibility review: dynamic feedback boxes are announced to screen readers, admonition titles carry a `lang` attribute for the selected language, `blockquote`/`section_outline` colors adapt to light/dark themes, `Columns`/`TwoColumn`/`ThreeColumn` reflow to a single column on narrow screens, and checkboxes show a visible keyboard-focus outline. See `accessibility.md` in the repository for full details, including one return-type change noted below where it applies.
+"""
+
 # ╔═╡ 3f8dc975-b091-4dbe-bd48-c33236e61ece
 using LaTeXStrings
 
@@ -176,6 +182,12 @@ md"""
 ## Some useful boxes
 """
 
+# ╔═╡ a02f3663-af9b-470f-922c-2ca6c188cd37
+md"""
+!!! warning "Return type note"
+	`correct`, `keep_working`, `still_missing`, `still_nothing`, and `wrong_type` now return an HTML object (for the new screen-reader announcement) instead of a `Markdown.MD` object. Displaying them in Pluto works exactly as before; only code that inspects the returned type or splices these into a larger `Markdown.MD(...)` document is affected. See `accessibility.md`.
+"""
+
 # ╔═╡ b48468f0-eeaa-4e1a-ad0b-3cfe42b6ab15
 correct()
 
@@ -296,6 +308,9 @@ section_outline("Example:", "Fancy section outline")
 # ╔═╡ 5a42a1b2-6300-4b81-9784-575b5f9a22ea
 md"""
 You can use the `section_outline` to make a section stand out! In our course, we use this for: "Problem statement" (in red) and "Solution" (in green).
+
+!!! warning "Choose colors with contrast in mind"
+	`color` is mixed with black/white to derive the text color, so a very light or very dark `color` can produce low-contrast text in one theme. See the `section_outline` docstring and `accessibility.md`.
 """
 
 # ╔═╡ cccaff2f-3fa0-45f2-9fa6-cf8a21ade844
@@ -394,6 +409,8 @@ Columns(md"Left col", md"Middle col", md"Right col")
 # ╔═╡ c22f7f6a-171d-4379-86c9-1781875cf0a4
 md"""
 You can customize the widths of the columns.
+
+*Note: columns now automatically stack into a single column on narrow/mobile screens (below 600px wide).*
 """
 
 # ╔═╡ 0e1e62a6-3b78-4415-89fe-fa17279fddbf
@@ -415,6 +432,8 @@ md"""
 # ╔═╡ b1f41633-82fd-4e67-9d57-f66623036417
 md"""
 Add a checkbox to choose to use the full browser window width (e.g., for large plots).
+
+*Note: these checkboxes now show a visible outline when focused via keyboard navigation.*
 """
 
 # ╔═╡ 1f417420-cc7f-4e88-9b2b-05185ff81c31
@@ -1009,6 +1028,7 @@ version = "17.4.0+2"
 # ╟─cd581a51-fb2b-4579-9a7d-0d723ad5d467
 # ╟─9b272420-8ab0-4b8e-9c4f-bf81a56227db
 # ╠═dee4aa68-e5eb-4a8a-869f-867e61de5ec5
+# ╟─ec6b46eb-8051-4ff8-a374-8baa51717f88
 # ╠═f0704e56-7e97-4c92-bbdd-76d7a873e6d8
 # ╟─84ccb960-41f8-430d-bd73-a7c0248cfb95
 # ╟─d6b3f009-22e4-4b21-8986-a29e3f261c3b
@@ -1034,6 +1054,7 @@ version = "17.4.0+2"
 # ╠═480dd2a0-8b37-42fa-855e-cd00fe50e1bb
 # ╟─c2180e12-c37a-461c-812a-80129d73426a
 # ╟─399f5b73-a554-4a98-acad-d4dd516865ad
+# ╟─a02f3663-af9b-470f-922c-2ca6c188cd37
 # ╠═b48468f0-eeaa-4e1a-ad0b-3cfe42b6ab15
 # ╠═cbea3a7b-522d-4f6e-908a-6baec22a9ce3
 # ╠═cf73022f-abfd-407c-bcb4-989b54b5dd03

--- a/example.jl
+++ b/example.jl
@@ -1,5 +1,5 @@
 ### A Pluto.jl notebook ###
-# v0.20.13
+# v1.0.3
 
 #> [frontmatter]
 #> license_url = "https://creativecommons.org/licenses/by-sa/4.0/"
@@ -31,12 +31,6 @@ end
 
 # ╔═╡ dee4aa68-e5eb-4a8a-869f-867e61de5ec5
 using PlutoUI    # Provides widgets like Select
-
-# ╔═╡ ec6b46eb-8051-4ff8-a374-8baa51717f88
-md"""
-!!! info "Accessibility improvements (unreleased)"
-	This version of the package includes fixes from a WCAG 2.1 AA accessibility review: dynamic feedback boxes are announced to screen readers, admonition titles carry a `lang` attribute for the selected language, `blockquote`/`section_outline` colors adapt to light/dark themes, `Columns`/`TwoColumn`/`ThreeColumn` reflow to a single column on narrow screens, and checkboxes show a visible keyboard-focus outline. See `accessibility.md` in the repository for full details, including one return-type change noted below where it applies.
-"""
 
 # ╔═╡ 3f8dc975-b091-4dbe-bd48-c33236e61ece
 using LaTeXStrings
@@ -292,10 +286,10 @@ begin
 end;
 
 # ╔═╡ 43a47026-4b09-4c20-9ccb-a766a17f8ff4
-RobustLocalResource(url, path; cache=false) # specify to not save a local copy
+RobustLocalResource(url, path, :alt => "Pluto logo"; cache=false) # specify to not save a local copy
 
 # ╔═╡ 4774a4d7-d5f1-40e4-8c2f-f0f96e9242ce
-RobustLocalResource(url, path, :width => 200, :alt => "Pluto logo") # add html attributes
+pluto_logo = RobustLocalResource(url, path, :alt => "Pluto logo", :width => 200) # cached by default
 
 # ╔═╡ d61ec51d-60c4-4f48-8179-2c8045416953
 md"""
@@ -303,12 +297,18 @@ md"""
 """
 
 # ╔═╡ 809de91f-90bf-4a59-b980-81ee80112414
-section_outline("Example:", "Fancy section outline")
+section_outline("Problem:", "Students can overlook problems.")
 
-# ╔═╡ 5a42a1b2-6300-4b81-9784-575b5f9a22ea
+# ╔═╡ 2945d6f5-6208-4601-8e6d-02ac70401553
 md"""
 You can use the `section_outline` to make a section stand out! In our course, we use this for: "Problem statement" (in red) and "Solution" (in green).
+"""
 
+# ╔═╡ 352561b5-72af-43e6-b495-0153b7b908fb
+section_outline("Solution:", "Use a fancy section outline", header_level=3, color=:red)
+
+# ╔═╡ bd305196-9a79-476e-b44c-6742ac9ec1cf
+md"""
 !!! warning "Choose colors with contrast in mind"
 	`color` is mixed with black/white to derive the text color, so a very light or very dark `color` can produce low-contrast text in one theme. See the `section_outline` docstring and `accessibility.md`.
 """
@@ -421,8 +421,7 @@ TwoColumnWideRight(md"Left col", md"Right col")
 
 # ╔═╡ 44d651d3-ce42-4061-b193-da7c31efed8e
 TwoColumnWideLeft(
-    warning_box(md"Discussion of figure on right."), RobustLocalResource(url, path)
-)
+    warning_box(md"Discussion of figure on right."), pluto_logo )
 
 # ╔═╡ 7859ad2b-7e87-442c-8684-f731f2512a42
 md"""
@@ -432,24 +431,14 @@ md"""
 # ╔═╡ b1f41633-82fd-4e67-9d57-f66623036417
 md"""
 Add a checkbox to choose to use the full browser window width (e.g., for large plots).
-
-*Note: these checkboxes now show a visible outline when focused via keyboard navigation.*
 """
 
 # ╔═╡ 1f417420-cc7f-4e88-9b2b-05185ff81c31
 WidthOverDocs()  
 
-# ╔═╡ c4d405ee-5b55-4e0b-9a95-3340cf6a0c7e
-md"""
-Or add a compact pair of checkboxes for both full width mode and presentation mode.  
-"""
-
-# ╔═╡ 96ebc3d2-fc70-4a56-8e87-dfe686c723c4
-ChooseDisplayMode()
-
 # ╔═╡ 17fa85c6-0e36-47d4-925e-fae0b4b61d4c
 protip(md"""
-You can also access presentation mode by clicking the Export and Start Presentation buttons at the very top of the Pluto notebook.  The checkbox below triggers a toggle, so using both the Start Presentation Button and the checkbox below can cause the displayed check to be out of sync with the current display mode.
+Recent versions of Pluto allow you to access presentation mode by clicking the Export and Start Presentation buttons at the very top of the Pluto notebook.  `ChooseDisplayMode()` shown below is kept for backward compatability, but deprecated since checkbox triggers a toggle, so using both the Start Presentation Button and the checkbox below can cause the displayed check to be out of sync with the current display mode.
 """, invite="Bulit-in Presentation Mode")
 
 # ╔═╡ 97967267-6dbe-4d13-b9cf-1be9038b23ab
@@ -581,6 +570,23 @@ demonstrate_ingredients && Demo.hundred
 # ╔═╡ 5985de1c-a429-4449-87c2-3eb6d5bfb247
 demonstrate_ingredients && hello()
 
+# ╔═╡ 3a1fcd79-f7bf-4285-91dd-57b6a5af3713
+md"""
+# Accessibility
+"""
+
+# ╔═╡ ec6b46eb-8051-4ff8-a374-8baa51717f88
+md"""
+PlutoTeachingTools.jl has been updated to meet WCAG 2.1 AA accessibility requirements, including:
+- dynamic feedback boxes are announced to screen readers, 
+- admonition titles carry a `lang` attribute for the selected language, 
+- `blockquote`/`section_outline` colors adapt to light/dark themes, 
+- `Columns`/`TwoColumn`/`ThreeColumn` reflow to a single column on narrow screens, and 
+- checkboxes show a visible keyboard-focus outline. 
+
+See accessibility.md in the repository for full details, including one return-type change.  If you notice accessibility issues, please submit an issue and/or pull request, so we can make PlutoTeachingTools.jl even better.
+"""
+
 # ╔═╡ 00000000-0000-0000-0000-000000000001
 PLUTO_PROJECT_TOML_CONTENTS = """
 [deps]
@@ -593,10 +599,10 @@ ShortCodes = "f62ebe17-55c5-4640-972f-b59c0dd11ccf"
 
 [compat]
 LaTeXStrings = "~1.4.0"
-MarkdownLiteral = "~0.1.1"
+MarkdownLiteral = "~0.1.2"
 PlutoLinks = "~0.1.6"
 PlutoTeachingTools = "~0.4.2"
-PlutoUI = "~0.7.61"
+PlutoUI = "~0.7.68"
 ShortCodes = "~0.3.6"
 """
 
@@ -604,9 +610,9 @@ ShortCodes = "~0.3.6"
 PLUTO_MANIFEST_TOML_CONTENTS = """
 # This file is machine-generated - editing it directly is not advised
 
-julia_version = "1.10.9"
+julia_version = "1.12.7"
 manifest_format = "2.0"
-project_hash = "eb3ebfbb90a68194f64456efdf32474739aa132c"
+project_hash = "55cb5e9b0a9e2246b451163cd365a29596c127e7"
 
 [[deps.AbstractPlutoDingetjes]]
 deps = ["Pkg"]
@@ -616,13 +622,15 @@ version = "1.3.2"
 
 [[deps.ArgTools]]
 uuid = "0dad84c5-d112-42e6-8d28-ef12dabb789f"
-version = "1.1.1"
+version = "1.1.2"
 
 [[deps.Artifacts]]
 uuid = "56f22d72-fd6d-98f1-02f0-08ddc0907c33"
+version = "1.11.0"
 
 [[deps.Base64]]
 uuid = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"
+version = "1.11.0"
 
 [[deps.CodeTracking]]
 deps = ["InteractiveUtils", "UUIDs"]
@@ -641,12 +649,10 @@ deps = ["FixedPointNumbers", "Random"]
 git-tree-sha1 = "67e11ee83a43eb71ddc950302c53bf33f0690dfe"
 uuid = "3da002f7-5984-5a60-b8a6-cbb66c0b333f"
 version = "0.12.1"
+weakdeps = ["StyledStrings"]
 
     [deps.ColorTypes.extensions]
     StyledStringsExt = "StyledStrings"
-
-    [deps.ColorTypes.weakdeps]
-    StyledStrings = "f489334b-da3d-4c2e-b8f0-e476e12c162b"
 
 [[deps.CommonMark]]
 deps = ["PrecompileTools"]
@@ -662,19 +668,21 @@ version = "0.1.1"
 [[deps.CompilerSupportLibraries_jll]]
 deps = ["Artifacts", "Libdl"]
 uuid = "e66e0078-7015-5450-92f7-15fbd957f2ae"
-version = "1.1.1+0"
+version = "1.3.1+2"
 
 [[deps.Dates]]
 deps = ["Printf"]
 uuid = "ade2ca70-3891-5945-98fb-dc099432e06a"
+version = "1.11.0"
 
 [[deps.Downloads]]
 deps = ["ArgTools", "FileWatching", "LibCURL", "NetworkOptions"]
 uuid = "f43a241f-c20a-4ad4-852c-f6b1247861c6"
-version = "1.6.0"
+version = "1.7.0"
 
 [[deps.FileWatching]]
 uuid = "7b1f6079-737a-58dc-b8bc-7a2ca5c1b5ee"
+version = "1.11.0"
 
 [[deps.FixedPointNumbers]]
 deps = ["Statistics"]
@@ -708,6 +716,7 @@ version = "0.2.5"
 [[deps.InteractiveUtils]]
 deps = ["Markdown"]
 uuid = "b77e0a4c-d291-57a0-90e8-8db25a27a240"
+version = "1.11.0"
 
 [[deps.JSON]]
 deps = ["Dates", "Mmap", "Parsers", "Unicode"]
@@ -732,6 +741,11 @@ deps = ["CodeTracking", "InteractiveUtils", "Random", "UUIDs"]
 git-tree-sha1 = "e09121f4c523d8d8d9226acbed9cb66df515fcf2"
 uuid = "aa1ae85d-cabe-5617-a682-6adf51b2e16a"
 version = "0.10.4"
+
+[[deps.JuliaSyntaxHighlighting]]
+deps = ["StyledStrings"]
+uuid = "ac6e5ff7-fb65-4e79-a425-ec3bc9c03011"
+version = "1.12.0"
 
 [[deps.LaTeXStrings]]
 git-tree-sha1 = "dda21b8cbd6a6c40d9d02a73230f9d70fed6918c"
@@ -762,33 +776,37 @@ uuid = "b27032c2-a3e7-50c8-80cd-2d36dbcbfd21"
 version = "0.6.4"
 
 [[deps.LibCURL_jll]]
-deps = ["Artifacts", "LibSSH2_jll", "Libdl", "MbedTLS_jll", "Zlib_jll", "nghttp2_jll"]
+deps = ["Artifacts", "LibSSH2_jll", "Libdl", "OpenSSL_jll", "Zlib_jll", "nghttp2_jll"]
 uuid = "deac9b47-8bc7-5906-a0fe-35ac56dc84c0"
-version = "8.4.0+0"
+version = "8.15.0+0"
 
 [[deps.LibGit2]]
-deps = ["Base64", "LibGit2_jll", "NetworkOptions", "Printf", "SHA"]
+deps = ["LibGit2_jll", "NetworkOptions", "Printf", "SHA"]
 uuid = "76f85450-5226-5b5a-8eaa-529ad045b433"
+version = "1.11.0"
 
 [[deps.LibGit2_jll]]
-deps = ["Artifacts", "LibSSH2_jll", "Libdl", "MbedTLS_jll"]
+deps = ["Artifacts", "LibSSH2_jll", "Libdl", "OpenSSL_jll"]
 uuid = "e37daf67-58a4-590a-8e99-b0245dd2ffc5"
-version = "1.6.4+0"
+version = "1.9.0+0"
 
 [[deps.LibSSH2_jll]]
-deps = ["Artifacts", "Libdl", "MbedTLS_jll"]
+deps = ["Artifacts", "Libdl", "OpenSSL_jll"]
 uuid = "29816b5a-b9ab-546f-933c-edad1886dfa8"
-version = "1.11.0+1"
+version = "1.11.3+1"
 
 [[deps.Libdl]]
 uuid = "8f399da3-3557-5675-b5ff-fb832c97cbdb"
+version = "1.11.0"
 
 [[deps.LinearAlgebra]]
 deps = ["Libdl", "OpenBLAS_jll", "libblastrampoline_jll"]
 uuid = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
+version = "1.12.0"
 
 [[deps.Logging]]
 uuid = "56ddb016-857b-54e1-b83d-db4d58db5568"
+version = "1.11.0"
 
 [[deps.LoweredCodeUtils]]
 deps = ["CodeTracking", "Compiler", "JuliaInterpreter"]
@@ -807,19 +825,15 @@ uuid = "1914dd2f-81c6-5fcd-8719-6d5c9610ff09"
 version = "0.5.16"
 
 [[deps.Markdown]]
-deps = ["Base64"]
+deps = ["Base64", "JuliaSyntaxHighlighting", "StyledStrings"]
 uuid = "d6f4376e-aef5-505a-96c1-9c027394607a"
+version = "1.11.0"
 
 [[deps.MarkdownLiteral]]
 deps = ["CommonMark", "HypertextLiteral"]
 git-tree-sha1 = "f7d73634acd573bf3489df1ee0d270a5d6d3a7a3"
 uuid = "736d6165-7244-6769-4267-6b50796e6954"
 version = "0.1.2"
-
-[[deps.MbedTLS_jll]]
-deps = ["Artifacts", "Libdl"]
-uuid = "c8ffd9c3-330d-5841-b78e-0817d7145fa1"
-version = "2.28.2+1"
 
 [[deps.Memoize]]
 deps = ["MacroTools"]
@@ -829,19 +843,25 @@ version = "0.4.4"
 
 [[deps.Mmap]]
 uuid = "a63ad114-7e13-5084-954f-fe012c677804"
+version = "1.11.0"
 
 [[deps.MozillaCACerts_jll]]
 uuid = "14a3606d-f60d-562e-9121-12d972cd8159"
-version = "2023.1.10"
+version = "2025.11.4"
 
 [[deps.NetworkOptions]]
 uuid = "ca575930-c2e3-43a9-ace4-1e988b2c1908"
-version = "1.2.0"
+version = "1.3.0"
 
 [[deps.OpenBLAS_jll]]
 deps = ["Artifacts", "CompilerSupportLibraries_jll", "Libdl"]
 uuid = "4536629a-c528-5b80-bd46-f80d51c5b363"
-version = "0.3.23+4"
+version = "0.3.29+0"
+
+[[deps.OpenSSL_jll]]
+deps = ["Artifacts", "Libdl"]
+uuid = "458c3c95-2e84-50aa-8efc-19380b2a3a95"
+version = "3.5.6+0"
 
 [[deps.OrderedCollections]]
 git-tree-sha1 = "05868e21324cede2207c6f0f466b4bfef6d5e7ee"
@@ -855,9 +875,13 @@ uuid = "69de0a69-1ddd-5017-9359-2bf0b02dc9f0"
 version = "2.8.3"
 
 [[deps.Pkg]]
-deps = ["Artifacts", "Dates", "Downloads", "FileWatching", "LibGit2", "Libdl", "Logging", "Markdown", "Printf", "REPL", "Random", "SHA", "Serialization", "TOML", "Tar", "UUIDs", "p7zip_jll"]
+deps = ["Artifacts", "Dates", "Downloads", "FileWatching", "LibGit2", "Libdl", "Logging", "Markdown", "Printf", "Random", "SHA", "TOML", "Tar", "UUIDs", "p7zip_jll"]
 uuid = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
-version = "1.10.0"
+version = "1.12.1"
+weakdeps = ["REPL"]
+
+    [deps.Pkg.extensions]
+    REPLExt = "REPL"
 
 [[deps.PlutoHooks]]
 deps = ["InteractiveUtils", "Markdown", "UUIDs"]
@@ -898,14 +922,17 @@ version = "1.4.3"
 [[deps.Printf]]
 deps = ["Unicode"]
 uuid = "de0858da-6303-5e67-8744-51eddeeeb8d7"
+version = "1.11.0"
 
 [[deps.REPL]]
-deps = ["InteractiveUtils", "Markdown", "Sockets", "Unicode"]
+deps = ["InteractiveUtils", "JuliaSyntaxHighlighting", "Markdown", "Sockets", "StyledStrings", "Unicode"]
 uuid = "3fa0cd96-eef1-5676-8a61-b3b8758bbffb"
+version = "1.11.0"
 
 [[deps.Random]]
 deps = ["SHA"]
 uuid = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
+version = "1.11.0"
 
 [[deps.Reexport]]
 git-tree-sha1 = "45e428421666073eab6f2da5c9d310d99bb12f9b"
@@ -936,6 +963,7 @@ version = "0.7.0"
 
 [[deps.Serialization]]
 uuid = "9e88b42a-f829-5b0c-bbe9-9e923198166b"
+version = "1.11.0"
 
 [[deps.ShortCodes]]
 deps = ["Base64", "CodecZlib", "Downloads", "JSON3", "Memoize", "URIs", "UUIDs"]
@@ -945,16 +973,19 @@ version = "0.3.6"
 
 [[deps.Sockets]]
 uuid = "6462fe0b-24de-5631-8697-dd941f90decc"
-
-[[deps.SparseArrays]]
-deps = ["Libdl", "LinearAlgebra", "Random", "Serialization", "SuiteSparse_jll"]
-uuid = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
-version = "1.10.0"
+version = "1.11.0"
 
 [[deps.Statistics]]
-deps = ["LinearAlgebra", "SparseArrays"]
+deps = ["LinearAlgebra"]
+git-tree-sha1 = "e2b53ce13a53367e96601081e33d34746b571bad"
 uuid = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
-version = "1.10.0"
+version = "1.11.5"
+
+    [deps.Statistics.extensions]
+    SparseArraysExt = ["SparseArrays"]
+
+    [deps.Statistics.weakdeps]
+    SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 
 [[deps.StructTypes]]
 deps = ["Dates", "UUIDs"]
@@ -962,10 +993,9 @@ git-tree-sha1 = "159331b30e94d7b11379037feeb9b690950cace8"
 uuid = "856f2bd8-1eba-4b0a-8007-ebc267875bd4"
 version = "1.11.0"
 
-[[deps.SuiteSparse_jll]]
-deps = ["Artifacts", "Libdl", "libblastrampoline_jll"]
-uuid = "bea87d4a-7f5b-5778-9afe-8cc45184846c"
-version = "7.2.1+1"
+[[deps.StyledStrings]]
+uuid = "f489334b-da3d-4c2e-b8f0-e476e12c162b"
+version = "1.11.0"
 
 [[deps.TOML]]
 deps = ["Dates"]
@@ -980,6 +1010,7 @@ version = "1.10.0"
 [[deps.Test]]
 deps = ["InteractiveUtils", "Logging", "Random", "Serialization"]
 uuid = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+version = "1.11.0"
 
 [[deps.TranscodingStreams]]
 git-tree-sha1 = "0c45878dcfdcfa8480052b6ab162cdd138781742"
@@ -999,36 +1030,37 @@ version = "1.6.1"
 [[deps.UUIDs]]
 deps = ["Random", "SHA"]
 uuid = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
+version = "1.11.0"
 
 [[deps.Unicode]]
 uuid = "4ec0a83e-493e-50e2-b9ac-8f72acf5a8f5"
+version = "1.11.0"
 
 [[deps.Zlib_jll]]
 deps = ["Libdl"]
 uuid = "83775a58-1f1d-513f-b197-d71354ab007a"
-version = "1.2.13+1"
+version = "1.3.1+2"
 
 [[deps.libblastrampoline_jll]]
 deps = ["Artifacts", "Libdl"]
 uuid = "8e850b90-86db-534c-a0d3-1478176c7d93"
-version = "5.11.0+0"
+version = "5.15.0+0"
 
 [[deps.nghttp2_jll]]
 deps = ["Artifacts", "Libdl"]
 uuid = "8e850ede-7688-5339-a07c-302acd2aaf8d"
-version = "1.52.0+1"
+version = "1.64.0+1"
 
 [[deps.p7zip_jll]]
-deps = ["Artifacts", "Libdl"]
+deps = ["Artifacts", "CompilerSupportLibraries_jll", "Libdl"]
 uuid = "3f19e933-33d8-53b3-aaab-bd5110c3b7a0"
-version = "17.4.0+2"
+version = "17.7.0+0"
 """
 
 # ╔═╡ Cell order:
 # ╟─cd581a51-fb2b-4579-9a7d-0d723ad5d467
 # ╟─9b272420-8ab0-4b8e-9c4f-bf81a56227db
 # ╠═dee4aa68-e5eb-4a8a-869f-867e61de5ec5
-# ╟─ec6b46eb-8051-4ff8-a374-8baa51717f88
 # ╠═f0704e56-7e97-4c92-bbdd-76d7a873e6d8
 # ╟─84ccb960-41f8-430d-bd73-a7c0248cfb95
 # ╟─d6b3f009-22e4-4b21-8986-a29e3f261c3b
@@ -1087,7 +1119,9 @@ version = "17.4.0+2"
 # ╠═4774a4d7-d5f1-40e4-8c2f-f0f96e9242ce
 # ╟─d61ec51d-60c4-4f48-8179-2c8045416953
 # ╠═809de91f-90bf-4a59-b980-81ee80112414
-# ╟─5a42a1b2-6300-4b81-9784-575b5f9a22ea
+# ╟─2945d6f5-6208-4601-8e6d-02ac70401553
+# ╠═352561b5-72af-43e6-b495-0153b7b908fb
+# ╟─bd305196-9a79-476e-b44c-6742ac9ec1cf
 # ╟─cccaff2f-3fa0-45f2-9fa6-cf8a21ade844
 # ╠═c46d1e7c-df6e-460e-a103-a486d27932c9
 # ╠═fb77557c-cbf1-4d91-bf4b-76abd54a4024
@@ -1118,8 +1152,6 @@ version = "17.4.0+2"
 # ╟─7859ad2b-7e87-442c-8684-f731f2512a42
 # ╟─b1f41633-82fd-4e67-9d57-f66623036417
 # ╠═1f417420-cc7f-4e88-9b2b-05185ff81c31
-# ╠═c4d405ee-5b55-4e0b-9a95-3340cf6a0c7e
-# ╠═96ebc3d2-fc70-4a56-8e87-dfe686c723c4
 # ╟─17fa85c6-0e36-47d4-925e-fae0b4b61d4c
 # ╟─97967267-6dbe-4d13-b9cf-1be9038b23ab
 # ╠═c83e0b4a-7376-4061-8796-ba396c9fbc7a
@@ -1144,5 +1176,7 @@ version = "17.4.0+2"
 # ╠═d4b1b5f2-b4ae-4988-aded-79398949f1c8
 # ╠═95528ca8-bb97-4af2-bbba-dbf1ac188622
 # ╠═5985de1c-a429-4449-87c2-3eb6d5bfb247
+# ╟─3a1fcd79-f7bf-4285-91dd-57b6a5af3713
+# ╟─ec6b46eb-8051-4ff8-a374-8baa51717f88
 # ╟─00000000-0000-0000-0000-000000000001
 # ╟─00000000-0000-0000-0000-000000000002

--- a/src/aside.jl
+++ b/src/aside.jl
@@ -32,12 +32,21 @@ Displays text on right hand side of Pluto notebook.
 Optional `v_offset` allows shifting down (positive) or up (negative).
 Optional integer parameter `width` defaults to 300px.
 Often combined with `tip(md"text")`.
+
+Since the `<aside>` is absolutely positioned outside the normal document
+flow (to float it beside the main content for sighted readers), assistive
+technology that walks the page in linear reading order may not encounter
+it where a sighted reader would expect. An `aria-label` is included so
+that a screen reader user who reaches it via a landmarks list still gets
+a clear description of the region. Because of this, content passed to
+`aside` should be supplementary/non-critical: don't put anything here
+that a reader needs in order to follow the main flow of the notebook.
 """
 function aside(x; v_offset::Integer=0)
     width = get_aside_width()
     if get_aside_has_been_setup()
         @htl("""
-      <aside class="plutoui-aside-wrapper" style="top: $(v_offset)px">
+      <aside class="plutoui-aside-wrapper" aria-label="Aside" style="top: $(v_offset)px">
       	<div>
       	$(x)
       	</div>
@@ -58,7 +67,7 @@ function aside(x; v_offset::Integer=0)
          }
       }
       </style>
-      <aside class="plutoui-aside-wrapper" style="top: $(v_offset)px">
+      <aside class="plutoui-aside-wrapper" aria-label="Aside" style="top: $(v_offset)px">
       	<div>
       	$(x)
       	</div>

--- a/src/computational_thinking.jl
+++ b/src/computational_thinking.jl
@@ -1,19 +1,37 @@
 import Markdown
 
-
-
 text_to_content(x) = x
 text_to_content(x::String) = @static(isdefined(Markdown, :parse) ? getfield(Markdown, :parse)(x) : x)
 
 
+"""
+Wraps rendered content in a `lang="xx"` div, so that assistive technology uses the
+correct voice/pronunciation for localized admonition titles instead of the
+surrounding document's language (WCAG 3.1.2 Language of Parts).
+
+The `Admonition` method renders via `Markdown.html` directly rather than going
+through `MD(admonition)` first, so the wrapper doesn't introduce a redundant nested
+`div.markdown` around the admonition.
+"""
+function wrap_lang(content, lang::AbstractLanguage)
+    lang_code = get_language_code(lang)
+    inner_html = repr(MIME"text/html"(), content)
+    return MD(@htl("""<div lang=$(isempty(lang_code) ? nothing : lang_code)>$(HTML(inner_html))</div>"""))
+end
+function wrap_lang(admonition::Admonition, lang::AbstractLanguage)
+    lang_code = get_language_code(lang)
+    inner_html = sprint(Markdown.html, admonition)
+    return MD(@htl("""<div lang=$(isempty(lang_code) ? nothing : lang_code)>$(HTML(inner_html))</div>"""))
+end
+
 "Hint box with arguement as text."
 function hint(text, lang::AbstractLanguage=default_language[])
-    return MD(Admonition("hint", hint_str(lang), [text_to_content(text)]))
+    return wrap_lang(Admonition("hint", hint_str(lang), [text_to_content(text)]), lang)
 end
 
 "Tip box with arguement as text."
 function tip(text, lang::AbstractLanguage=default_language[])
-    return MD(Admonition("tip", tip_str(lang), [text_to_content(text)]))
+    return wrap_lang(Admonition("tip", tip_str(lang), [text_to_content(text)]), lang)
 end
 
 "Tip box with arguement as text."
@@ -23,7 +41,7 @@ function protip(
     invite=protip_invite_str(lang),
     boxlabel=protip_boxlabel_str(lang),
 )
-    return Foldable(invite, MD(Admonition("tip", boxlabel, [text_to_content(text)])))
+    return wrap_lang(Foldable(invite, MD(Admonition("tip", boxlabel, [text_to_content(text)]))), lang)
 end
 function protip(
     text,
@@ -41,7 +59,7 @@ function answer_box(
     invite=answer_invite_str(lang),
     boxlabel=answer_boxlabel_str(lang),
 )
-    return Foldable(invite, MD(Admonition("answer", boxlabel, [text_to_content(text)])))
+    return wrap_lang(Foldable(invite, MD(Admonition("answer", boxlabel, [text_to_content(text)]))), lang)
 end
 function answer_box(
     text,
@@ -54,34 +72,48 @@ end
 
 "Admonition box labeled a warning with arguement as text."
 function almost(text, lang::AbstractLanguage=default_language[])
-    return MD(Admonition("warning", almost_str(lang), [text_to_content(text)]))
+    return wrap_lang(Admonition("warning", almost_str(lang), [text_to_content(text)]), lang)
 end
 
 "Warning box with arguement as text."
 function warning_box(text, lang::AbstractLanguage=default_language[])
-    return MD(Admonition("warning", warning_box_str(lang), [text_to_content(text)]))
+    return wrap_lang(Admonition("warning", warning_box_str(lang), [text_to_content(text)]), lang)
 end
 
 "Question box with arguement as text."
 function question_box(text, lang::AbstractLanguage=default_language[])
-    return MD(Admonition("question", question_box_str(lang), [text_to_content(text)]))
+    return wrap_lang(Admonition("question", question_box_str(lang), [text_to_content(text)]), lang)
 end
 
 "Key concept box with concept name and description as input arguments."
 function keyconcept(concept, text, lang::AbstractLanguage=default_language[])
-    return MD(Admonition("key-concept", keyconcept_str(lang), [md"**$concept**", text_to_content(text)]))
+    return wrap_lang(Admonition("key-concept", keyconcept_str(lang), [md"**$concept**", text_to_content(text)]), lang)
 end
 
 "Danger box with arguement as text."
 function danger(text, lang::AbstractLanguage=default_language[])
-    return MD(Admonition("danger", danger_str(lang), [text_to_content(text)]))
+    return wrap_lang(Admonition("danger", danger_str(lang), [text_to_content(text)]), lang)
+end
+
+"""
+Wraps rendered admonition HTML in an ARIA live region, so that assistive
+technology announces feedback boxes as they appear/change (WCAG 4.1.3
+Status Messages) instead of requiring the user to notice them visually.
+
+Also carries the `lang` attribute for the localized title inside (WCAG 3.1.2
+Language of Parts) on the same element, rather than nesting a second wrapper div.
+"""
+function aria_live_status(content, lang::AbstractLanguage)
+    inner_html = repr(MIME"text/html"(), content)
+    lang_code = get_language_code(lang)
+    return @htl("""<div lang=$(isempty(lang_code) ? nothing : lang_code) role="status" aria-live="polite" aria-atomic="true">$(HTML(inner_html))</div>""")
 end
 
 "Admonition box with reminder to replace missing."
 function still_missing(;
     lang::AbstractLanguage=default_language[], text=still_missing_text_str(lang)
 )
-    return MD(Admonition("warning", still_missing_str(lang), [text_to_content(text)]))
+    return aria_live_status(MD(Admonition("warning", still_missing_str(lang), [text_to_content(text)])), lang)
 end
 still_missing(text, lang::AbstractLanguage=default_language[]) = still_missing(; lang, text)
 
@@ -89,12 +121,12 @@ still_missing(text, lang::AbstractLanguage=default_language[]) = still_missing(;
 function still_nothing(;
     lang::AbstractLanguage=default_language[], text=still_nothing_text_str(lang)
 )
-    return MD(Admonition("warning", still_nothing_str(lang), [text_to_content(text)]))
+    return aria_live_status(MD(Admonition("warning", still_nothing_str(lang), [text_to_content(text)])), lang)
 end
 still_nothing(text, lang::AbstractLanguage=default_language[]) = still_nothing(; lang, text)
 
 function wrong_type(lang::AbstractLanguage=default_language[])
-    return MD(Admonition("danger", wrong_type_str(lang), [wrong_type_text_str(lang)]))
+    return aria_live_status(MD(Admonition("danger", wrong_type_str(lang), [wrong_type_text_str(lang)])), lang)
 end
 
 function wrong_type(
@@ -103,28 +135,30 @@ function wrong_type(
     lang::AbstractLanguage=default_language[];
     text=wrong_type_text_str(lang, var, type),
 )
-    return MD(Admonition("danger", wrong_type_str(lang), [text_to_content(text)]))
+    return aria_live_status(MD(Admonition("danger", wrong_type_str(lang), [text_to_content(text)])), lang)
 end
 
 "Admonition box with reminder that function name passed is not defined."
 function func_not_defined(func_name, lang::AbstractLanguage=default_language[])
-    return MD(
+    return wrap_lang(
         Admonition(
             "danger",
             func_not_defined_str(lang),
             [func_not_defined_text_str(func_name, lang)],
         ),
+        lang,
     )
 end
 
 "Admonition box with reminder that variable name passed is not defined."
 function var_not_defined(variable_name, lang::AbstractLanguage=default_language[])
-    return MD(
+    return wrap_lang(
         Admonition(
             "danger",
             var_not_defined_str(lang),
             [var_not_defined_text_str(variable_name, lang)],
         ),
+        lang,
     )
 end
 
@@ -137,7 +171,7 @@ end
 function keep_working(;
     lang::AbstractLanguage=default_language[], text=keep_working_text_str(lang)
 )
-    return MD(Admonition("danger", keep_working_str(lang), [text_to_content(text)]))
+    return aria_live_status(MD(Admonition("danger", keep_working_str(lang), [text_to_content(text)])), lang)
 end
 keep_working(text, lang::AbstractLanguage=default_language[]) = keep_working(; lang, text);
 
@@ -147,9 +181,9 @@ function keep_working_if_var_contains_substr(
     # I had to remove !@isdefined(var) due to how Pluto puts variables into different modules
     # not exported, so provide function with same name in notebook
     if ismissing(var)
-        still_missing()
+        still_missing(; lang)
     elseif isnothing(var)
-        still_nothing()
+        still_nothing(; lang)
     else
         if occursin(substr, str)
             keep_working(keep_working_update_str(var, lang))
@@ -188,7 +222,7 @@ function check_type_isa(sym::Symbol, var, t::Union{Type,Vector{Type},Vector{Data
               end
            end
         end
-        msg = Markdown.MD(Markdown.Admonition("danger", PlutoTeachingTools.check_type_isa_type_error_str(sym, lang), [Markdown.parse(text)]))
+        msg = PlutoTeachingTools.wrap_lang(Markdown.Admonition("danger", PlutoTeachingTools.check_type_isa_type_error_str(sym, lang), [Markdown.parse(text)]), lang)
     else
         passed = true
         msg = PlutoTeachingTools.check_type_isa_not_missing_text_str(sym, lang)
@@ -215,7 +249,7 @@ function check_type_eq(sym::Symbol, var, t::Union{Type,Vector{Type},Vector{DataT
            end
         end
         #text = md"The type of \$sym should be \$t."
-        msg = Markdown.MD(Markdown.Admonition("danger", PlutoTeachingTools.check_type_eq_type_error_str(lang), [Markdown.parse(text)]))
+        msg = PlutoTeachingTools.wrap_lang(Markdown.Admonition("danger", PlutoTeachingTools.check_type_eq_type_error_str(lang), [Markdown.parse(text)]), lang)
     else
         passed = true
         msg = PlutoTeachingTools.check_type_eq_correct_str(sym, lang)
@@ -227,7 +261,7 @@ end
 
 "Box with random positive message."
 function correct(; lang::AbstractLanguage=default_language[], text=rand(yays(lang)))
-    return MD(Admonition("correct", correct_str(lang), [text_to_content(text)]))
+    return aria_live_status(MD(Admonition("correct", correct_str(lang), [text_to_content(text)])), lang)
 end
 correct(text, lang::AbstractLanguage=default_language[]) = correct(; lang, text)
 
@@ -249,7 +283,7 @@ function TODO(; lang::AbstractLanguage=default_language[], text="", heading=todo
     <div class="ptt-todo-tape">
     </div> 
     <div class="ptt-todo-content">
-    <h1>&#9888; $heading &#9888;</h1>
+    <h1><span aria-hidden="true">&#9888;</span> $heading <span aria-hidden="true">&#9888;</span></h1>
     <p>$text</p>
     </div> 
     <div class="ptt-todo-tape">
@@ -294,29 +328,29 @@ function blockquote(text, author="")
     @htl("""
     <div class="nice-blockquote nice-blockquote__bordered nice-blockquote--quoted">
     <p class="nice-blockquote__text">
+    <span class="nice-blockquote__quote-mark nice-blockquote__quote-mark--open" aria-hidden="true">&ldquo;</span>
     $text
+    <span class="nice-blockquote__quote-mark nice-blockquote__quote-mark--close" aria-hidden="true">&rdquo;</span>
     </p>
     <div class="nice-blockquote__text nice-blockquote__text--author">
     $author
-    </div> 
-    </div> 
-    <style> 
+    </div>
+    </div>
+    <style>
     .nice-blockquote{
     padding: 25px;
-    border: 0.5px solid #ccc;
+    border: 0.5px solid color-mix(in srgb, currentColor 40%, transparent);
     box-sizing:border-box;
     overflow-y:hidden;
     }
     .nice-blockquote__bordered{
     border-left-width: 14px;
     }
-    p.nice-blockquote__text::before,
-    p.nice-blockquote__text::after{
-        content: open-quote;
+    .nice-blockquote__quote-mark{
         font-size: 70px;
         font-family: Arial;
         font-weight: bold;
-        color: #ccc;
+        color: color-mix(in srgb, currentColor 40%, transparent);
         display: block;
         /* margin-top: -20px; */
         /* margin-bottom: -40px; */
@@ -324,18 +358,17 @@ function blockquote(text, author="")
         float: left;
         /* padding: 0.1ch 1ch; */
     }
-    
-    p.nice-blockquote__text::before{
+
+    .nice-blockquote__quote-mark--open{
         padding-inline-end: .2ch;
         line-height: 0.5;
     }
-    p.nice-blockquote__text::after{
-        content: close-quote;
+    .nice-blockquote__quote-mark--close{
         float: right;
         padding-inline-start: .2ch;
             line-height: .7;
     }
-        
+
     .nice-blockquote__text{
     font-family: Arial;
     font-style: italic;
@@ -372,6 +405,8 @@ section_outline(
     header_level::Int=2, # the level of the header to use. 2 means a ## header, 3 means a ### header, etc.
 )
 ```
+
+`color` is mixed with black (light theme) or white (dark theme) via CSS `color-mix()` to derive the text color, rather than used directly, so that the text reads darker/lighter than the outline itself. Because of this, a light `color` (e.g. `"yellow"`, `"lime"`) can still mix into low-contrast text against a light background, and a dark `color` can do the same against a dark background. Choose a `color` that stays legible after this mixing in both themes (see [WCAG 1.4.3](https://www.w3.org/WAI/WCAG21/Understanding/contrast-minimum.html)); the package cannot verify contrast for an arbitrary user-supplied color.
 
 
 # Example

--- a/src/i18n/i18n.jl
+++ b/src/i18n/i18n.jl
@@ -91,6 +91,30 @@ import .PTTSpanish: SpanishES, SpanishFormal, SpanishColloquial
 include("chinese.jl")
 import .PTTChinese: ChineseZH
 
+"""
+Returns the BCP47 language code (e.g. `"fr"`) for `lang`, so callers can set the HTML
+`lang` attribute on localized content (WCAG 3.1.2 Language of Parts) — without it,
+assistive technology reads localized admonition titles using the surrounding
+document's language, in the wrong accent/voice.
+
+Formal/colloquial registers of the same language share one code, since BCP47 has no
+register subtag. Falls back to `""` (no attribute emitted) for languages registered
+by a package user via `register_language!` that have no code defined here.
+"""
+# Note: FrenchBelgium === FrenchBelgiumColloquial, GermanGermany === GermanGermanyFormal,
+# and SpanishES === SpanishFormal (type aliases defined in the respective language
+# files), so each concrete struct gets exactly one method below.
+get_language_code(::AbstractLanguage) = ""
+get_language_code(::EnglishUS) = "en"
+get_language_code(::FrenchBelgiumFormal) = "fr"
+get_language_code(::FrenchBelgiumColloquial) = "fr"
+get_language_code(::GermanGermanyFormal) = "de"
+get_language_code(::GermanGermanyColloquial) = "de"
+get_language_code(::RussianRU) = "ru"
+get_language_code(::SpanishFormal) = "es"
+get_language_code(::SpanishColloquial) = "es"
+get_language_code(::ChineseZH) = "zh"
+
 const languages_registered = Dict(
     "en" => EnglishUS(),
     "en_us" => EnglishUS(),

--- a/src/other.jl
+++ b/src/other.jl
@@ -25,6 +25,12 @@ function WidthOverDocs(
    	       # max-width: calc(100% - 4rem);
                   # margin-right: 2rem;
    	}
+   	/* WCAG 2.4.7 (Focus Visible): make keyboard focus visible on this
+   	   checkbox, scoped by id so other checkboxes are unaffected. */
+   	#width-over-livedocs:focus-visible {
+   		outline: 2px solid #4A90E2;
+   		outline-offset: 2px;
+   	}
    </style>
    <script>
    	const toggle_width = function(t) {

--- a/src/present.jl
+++ b/src/present.jl
@@ -51,7 +51,31 @@ function Columns(cols...; widths=nothing, gap=2)
     # i.e. [a, b, c] ==> [a, gap, b, gap, c]
     children = vec([reshape(columns, 1, :); fill(the_gap, 1, ncols)])[1:(end - 1)]
 
-    return Div(children; style=Dict("display" => "flex", "flex-direction" => "row"))
+    # Unique class per call, so that (a) the <style> block below only affects
+    # this instance and (b) multiple Columns()/TwoColumn()/ThreeColumn() calls
+    # on the same page don't clash with each other.
+    # WCAG 1.4.10 (Reflow): fixed-percentage-width columns become unreadably
+    # narrow (or require horizontal scrolling) once the viewport shrinks to
+    # the 320px minimum reflow width, so stack columns vertically below a
+    # 600px breakpoint. This must live in a real <style> block (rather than
+    # an inline `style="..."` attribute) because inline styles cannot contain
+    # `@media` rules.
+    id = "pluto-columns-$(string(rand(UInt64); base=16))"
+
+    row = Div(
+        children; style=Dict("display" => "flex", "flex-direction" => "row"), class=id
+    )
+
+    return @htl("""
+    <style>
+    @media (max-width: 600px) {
+        .$(id) {
+            flex-direction: column !important;
+        }
+    }
+    </style>
+    $(row)
+    """)
 end
 
 TwoColumn(a, b; kwargs...) = Columns(a, b; kwargs...)
@@ -92,6 +116,16 @@ function ChooseDisplayMode(;
                 #align-self: flex-star;
                 #margin-left: 50px;
                 #margin-right: 2rem;
+        }
+        /* WCAG 2.4.7 (Focus Visible): make keyboard focus visible on these
+           checkboxes, scoped by id so other checkboxes are unaffected. */
+        #width-over-livedocs:focus-visible {
+            outline: 2px solid #4A90E2;
+            outline-offset: 2px;
+        }
+        #present-mode:focus-visible {
+            outline: 2px solid #4A90E2;
+            outline-offset: 2px;
         }
 </style>
 <script>

--- a/test/aside.jl
+++ b/test/aside.jl
@@ -1,0 +1,18 @@
+@test_nowarn aside("testing aside")
+@test_nowarn aside("testing aside with offset", v_offset=50)
+@test_nowarn aside(md"testing in markdown")
+@test_nowarn aside(tip(md"Good tip here"))
+@test_nowarn aside(md"""
+ Testing
+ Multi-line
+ """)
+
+@testset "aria-label" begin
+    html_str = repr(MIME"text/html"(), aside("testing aside"))
+    # WCAG 1.3.1 (Info and Relationships): the <aside> is absolutely
+    # positioned out of normal document flow, so an aria-label helps
+    # screen reader users who reach it via a landmarks list understand
+    # what the region is.
+    @test occursin("<aside", html_str)
+    @test occursin("aria-label", html_str)
+end

--- a/test/computational_thinking.jl
+++ b/test/computational_thinking.jl
@@ -1,0 +1,145 @@
+@testset "ARIA live region on feedback admonitions (WCAG 4.1.3)" begin
+    # These functions render dynamic feedback in Pluto notebooks (e.g. "Correct!").
+    # Screen readers only announce such changes if the HTML carries an ARIA live
+    # region, so we check that role="status" and aria-live="polite" are present.
+    function has_status_live_region(x)
+        html_str = repr(MIME"text/html"(), x)
+        return occursin("role=\"status\"", html_str) && occursin("aria-live=\"polite\"", html_str)
+    end
+
+    @test has_status_live_region(correct())
+    @test has_status_live_region(correct("Nice job!"))
+
+    @test has_status_live_region(keep_working())
+    @test has_status_live_region(keep_working("Almost there."))
+
+    @test has_status_live_region(still_missing())
+    @test has_status_live_region(still_missing("Variable xxx is missing."))
+
+    @test has_status_live_region(still_nothing())
+    @test has_status_live_region(still_nothing("Variable xxx is nothing."))
+
+    @test has_status_live_region(wrong_type())
+    @test has_status_live_region(wrong_type(:x, Int))
+end
+
+@testset "TODO() decorative warning icon (WCAG 1.1.1)" begin
+    # TODO() surrounds its heading with a warning-sign glyph purely for visual
+    # framing. Without aria-hidden, a screen reader announces "warning sign" as
+    # if it were content (e.g. "warning sign, TODO, warning sign"). The glyph(s)
+    # must be wrapped in <span aria-hidden="true">...</span> so they are skipped.
+    html_str = repr(MIME"text/html"(), TODO())
+
+    @test occursin("&#9888;", html_str)
+    @test occursin("<span aria-hidden=\"true\">&#9888;</span>", html_str)
+    # There are two decorative occurrences, flanking the heading text.
+    @test count("<span aria-hidden=\"true\">&#9888;</span>", html_str) == 2
+
+    html_str_with_text = repr(MIME"text/html"(), TODO("Finish this section."))
+    @test count("<span aria-hidden=\"true\">&#9888;</span>", html_str_with_text) == 2
+end
+
+@testset "blockquote() border/quote-mark contrast (WCAG 1.4.3)" begin
+    # The border and decorative quote marks used to be a hardcoded #ccc, which is
+    # invisible/fails contrast against a dark background in Pluto's dark theme.
+    # They must instead be theme-aware (e.g. derived from currentColor via
+    # color-mix, or overridden in a prefers-color-scheme: dark block, or driven
+    # by a CSS custom property) so they remain visible in both themes.
+    html_str = repr(MIME"text/html"(), blockquote("A wise quote", "Someone wise"))
+
+    @test !occursin("#ccc", html_str)
+
+    is_theme_aware = occursin("prefers-color-scheme", html_str) ||
+                      occursin("var(--", html_str) ||
+                      occursin("color-mix", html_str)
+    @test is_theme_aware
+end
+
+@testset "blockquote() decorative quote marks (WCAG 1.1.1)" begin
+    # The decorative quote-mark glyphs used to be generated purely via CSS
+    # `content: open-quote` / `content: close-quote` on ::before/::after
+    # pseudo-elements, which are not real DOM text. Screen reader behavior for
+    # CSS-generated content is inconsistent (some announce "quotation mark",
+    # others announce nothing). The glyphs must instead be real HTML text
+    # wrapped in <span aria-hidden="true">...</span> so they are reliably
+    # skipped, since the <blockquote>-style semantics/text already convey
+    # that this is a quotation.
+    html_str = repr(MIME"text/html"(), blockquote("A wise quote", "Someone wise"))
+
+    @test !occursin("open-quote", html_str)
+    @test !occursin("close-quote", html_str)
+
+    @test occursin("<span class=\"nice-blockquote__quote-mark nice-blockquote__quote-mark--open\" aria-hidden=\"true\">&ldquo;</span>", html_str)
+    @test occursin("<span class=\"nice-blockquote__quote-mark nice-blockquote__quote-mark--close\" aria-hidden=\"true\">&rdquo;</span>", html_str)
+    @test count("aria-hidden=\"true\"", html_str) == 2
+end
+
+@testset "Language of localized parts (WCAG 3.1.2)" begin
+    # Localized admonition titles (e.g. "Conseil:" for French) must carry a `lang`
+    # attribute distinct from the document language, or a screen reader will read
+    # them in the wrong language/accent.
+    function html_of(x)
+        return repr(MIME"text/html"(), x)
+    end
+
+    @testset "get_language_code" begin
+        @test PlutoTeachingTools.get_language_code(PlutoTeachingTools.EnglishUS()) == "en"
+        @test PlutoTeachingTools.get_language_code(PlutoTeachingTools.PTTFrench.FrenchBelgium()) == "fr"
+        @test PlutoTeachingTools.get_language_code(PlutoTeachingTools.PTTFrench.FrenchBelgiumFormal()) == "fr"
+        @test PlutoTeachingTools.get_language_code(PlutoTeachingTools.PTTFrench.FrenchBelgiumColloquial()) == "fr"
+        @test PlutoTeachingTools.get_language_code(PlutoTeachingTools.PTTGerman.GermanGermany()) == "de"
+        @test PlutoTeachingTools.get_language_code(PlutoTeachingTools.PTTGerman.GermanGermanyFormal()) == "de"
+        @test PlutoTeachingTools.get_language_code(PlutoTeachingTools.PTTGerman.GermanGermanyColloquial()) == "de"
+        @test PlutoTeachingTools.get_language_code(PlutoTeachingTools.PTTRussian.RussianRU()) == "ru"
+        @test PlutoTeachingTools.get_language_code(PlutoTeachingTools.PTTSpanish.SpanishES()) == "es"
+        @test PlutoTeachingTools.get_language_code(PlutoTeachingTools.PTTSpanish.SpanishFormal()) == "es"
+        @test PlutoTeachingTools.get_language_code(PlutoTeachingTools.PTTSpanish.SpanishColloquial()) == "es"
+        @test PlutoTeachingTools.get_language_code(PlutoTeachingTools.PTTChinese.ChineseZH()) == "zh"
+    end
+
+    @testset "Rendered HTML carries lang attribute" begin
+        fr = PlutoTeachingTools.PTTFrench.FrenchBelgium()
+        ru = PlutoTeachingTools.PTTRussian.RussianRU()
+
+        has_lang(html_str, code) = occursin("lang='$(code)'", html_str) || occursin("lang=\"$(code)\"", html_str)
+
+        @test has_lang(html_of(tip("Un texte", fr)), "fr")
+        @test has_lang(html_of(hint("Un texte", fr)), "fr")
+        @test has_lang(html_of(correct(; lang=fr)), "fr")
+        @test has_lang(html_of(still_missing(; lang=ru)), "ru")
+        @test has_lang(html_of(keep_working(; lang=ru)), "ru")
+
+        # English (the document's assumed base language) still gets an explicit
+        # lang="en" so nested content is unambiguous regardless of page language.
+        @test has_lang(html_of(tip("Some text")), "en")
+
+        # The ARIA live region and the lang attribute live on the same element.
+        correct_html = html_of(correct(; lang=ru))
+        @test occursin("role=\"status\"", correct_html)
+        @test has_lang(correct_html, "ru")
+
+        # protip/answer_box wrap a Foldable (not an Admonition) and localize the
+        # <summary> "invite" text outside the inner admonition, so the lang div
+        # must enclose the whole Foldable, not just the admonition.
+        @test has_lang(html_of(protip("Un texte"; lang=fr)), "fr")
+        @test has_lang(html_of(answer_box("Une réponse"; lang=fr)), "fr")
+
+        # func_not_defined/var_not_defined also build a localized Admonition directly.
+        @test has_lang(html_of(func_not_defined(sin, ru)), "ru")
+        @test has_lang(html_of(var_not_defined(:x, ru)), "ru")
+
+        # code_for_check_type_funcs (eval'd into a notebook) builds its "type error"
+        # admonitions from a raw Markdown.Admonition, a separate path from wrap_lang's
+        # normal callers above; make sure it is wrapped too.
+        eval(Meta.parse(PlutoTeachingTools.code_for_check_type_funcs))
+        result = check_type_isa(:x, missing, Int, ru) # exercises the "missing" branch (still_missing, already covered)
+        @test result.passed == false
+        result = check_type_isa(:x, "not an int", Int, ru) # exercises the Admonition-building branch
+        @test has_lang(html_of(result.msg), "ru")
+        # Use a Vector{Type} `t` here: the scalar-`t` branch of check_type_eq has a
+        # pre-existing unrelated bug (references an undefined `type` variable) that
+        # is out of scope for this WCAG fix.
+        result = check_type_eq(:x, 1.0, [Int], ru)
+        @test has_lang(html_of(result.msg), "ru")
+    end
+end

--- a/test/other.jl
+++ b/test/other.jl
@@ -1,0 +1,7 @@
+@testset "WidthOverDocs" begin
+    html_str = repr(MIME"text/html"(), WidthOverDocs())
+    # WCAG 2.4.7 (Focus Visible): keyboard focus on the checkbox must be
+    # visibly indicated via a :focus-visible outline rule.
+    @test occursin("#width-over-livedocs:focus-visible", html_str)
+    @test occursin("outline", html_str)
+end

--- a/test/present.jl
+++ b/test/present.jl
@@ -1,0 +1,40 @@
+@testset "Columns" begin
+    html_str = repr(MIME"text/html"(), Columns(md"a", md"b", md"c"))
+    @test occursin("@media (max-width: 600px)", html_str)
+    @test occursin("flex-direction: column", html_str)
+    @test occursin("display: flex", html_str)
+
+    # each call should get its own unique class, so multiple Columns() on one
+    # page don't clash with each other
+    html_str1 = repr(MIME"text/html"(), Columns(md"a", md"b"))
+    html_str2 = repr(MIME"text/html"(), Columns(md"c", md"d"))
+    class1 = match(r"class=[\"']([^\"']+)[\"']", html_str1)[1]
+    class2 = match(r"class=[\"']([^\"']+)[\"']", html_str2)[1]
+    @test class1 != class2
+end
+
+@testset "TwoColumn" begin
+    html_str = repr(MIME"text/html"(), TwoColumn(md"a", md"b"))
+    @test occursin("@media (max-width: 600px)", html_str)
+    @test occursin("flex-direction: column", html_str)
+end
+
+@testset "ThreeColumn" begin
+    html_str = repr(MIME"text/html"(), ThreeColumn(md"a", md"b", md"c"))
+    @test occursin("@media (max-width: 600px)", html_str)
+    @test occursin("flex-direction: column", html_str)
+end
+
+@testset "TwoColumnWideLeft/Right" begin
+    @test_nowarn TwoColumnWideLeft(md"a", md"b")
+    @test_nowarn TwoColumnWideRight(md"a", md"b")
+end
+
+@testset "ChooseDisplayMode" begin
+    html_str = repr(MIME"text/html"(), ChooseDisplayMode())
+    # WCAG 2.4.7 (Focus Visible): keyboard focus on the checkboxes must be
+    # visibly indicated via an :focus-visible outline rule.
+    @test occursin("#width-over-livedocs:focus-visible", html_str)
+    @test occursin("#present-mode:focus-visible", html_str)
+    @test occursin("outline", html_str)
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -9,6 +9,14 @@ using Markdown
         end
     end
 
+    @testset "Computational thinking" begin
+        include("computational_thinking.jl")
+    end
+
+    @testset "Present" begin
+        include("present.jl")
+    end
+
     @testset "Admonitions" begin
         @testset "Standard String arguments" begin
             @test_nowarn hint("Test hint")
@@ -30,14 +38,7 @@ using Markdown
     end
 
     @testset "aside" begin
-        @test_nowarn aside("testing aside")
-        @test_nowarn aside("testing aside with offset", v_offset=50)
-        @test_nowarn aside(md"testing in markdown")
-        @test_nowarn aside(tip(md"Good tip here"))
-        @test_nowarn aside(md"""
- Testing
- Multi-line
- """)
+        include("aside.jl")
     end
 
     @testset "Useful strings" begin
@@ -46,5 +47,9 @@ using Markdown
 
     @testset "Changing width" begin
         @test_nowarn WidthOverDocs()
+    end
+
+    @testset "Other" begin
+        include("other.jl")
     end
 end


### PR DESCRIPTION
## Summary of changes

| Function(s) | WCAG criterion | Fix |
|---|---|---|
| `correct`, `keep_working`, `still_missing`, `still_nothing`, `wrong_type` | 4.1.3 Status Messages | Output wrapped in `role="status" aria-live="polite" aria-atomic="true"` so screen readers announce feedback as it appears. |
| `hint`, `tip`, `almost`, `warning_box`, `question_box`, `keyconcept`, `danger`, `func_not_defined`, `var_not_defined`, `protip`, `answer_box`, and the boxes above | 3.1.2 Language of Parts | Localized admonition titles wrapped in `lang="xx"` (via new `get_language_code(lang)` in `src/i18n/i18n.jl`) so assistive technology uses the correct voice for the notebook's selected language. |
| `blockquote` | 1.4.3 Contrast (Minimum) | Border and quote-mark color changed from hardcoded `#ccc` to `color-mix(in srgb, currentColor 40%, transparent)`, which tracks the current theme's text color instead of failing contrast in dark mode. |
| `section_outline` | 1.4.3 Contrast (Minimum) | Documentation only — see [Custom colors in `section_outline`](#custom-colors-in-section_outline) below. |
| `Columns`, `TwoColumn`, `ThreeColumn`, `TwoColumnWideLeft`, `TwoColumnWideRight` | 1.4.10 Reflow | Columns now stack into a single column below a 600px viewport width instead of staying in a fixed-percentage row that becomes unreadably narrow. |
| `TODO` | 1.1.1 Non-text Content | Decorative warning-sign glyphs wrapped in `<span aria-hidden="true">` so screen readers don't announce them. |
| `blockquote` | 1.1.1 Non-text Content | Quote marks moved from CSS `content: open-quote`/`close-quote` (inconsistent screen reader behavior) to real `<span aria-hidden="true">` text. |
| `ChooseDisplayMode`, `WidthOverDocs` | 2.4.7 Focus Visible | Checkboxes now show a `:focus-visible` outline for keyboard navigation. |
| `aside` | 1.3.1 Info and Relationships | Added `aria-label="Aside"`, and a docstring note that `aside` content should be supplementary/non-critical (see below). |

## Compatibility notes

None of the above changed any function's **signature** — every function still takes the same
positional/keyword arguments it did before. Existing notebooks that just call these functions and
display the result work unchanged. A few things did change under the hood, and matter only if you
do something more advanced than displaying the output directly: